### PR TITLE
feat: Add dask array based n5 to multiscale zarr converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,12 @@
 
 Code repository to be installed in exaSPIM processing capsules.
 
-Wrapper code for ImageJ automation.
+## Features
 
-## ImageJ wrapper module
+ - Wrapper code for ImageJ automation.
+ - n5 to zarr converter to be run in a Code Ocean capsule.
+
+### ImageJ wrapper module
 
 The ImageJ wrapper module contains Fiji macro templates and wrapper code to 
 automatically run interest point detection and interest point based registration
@@ -18,6 +21,28 @@ the package if the whole package is invoked on the command line or the
 ```bash
 python -m aind_exaspim_pipeline_utils
 ```
+
+### N5 to Zarr converter
+
+The N5 to zarr converter sets up a local dask cluster with multiple python processes 
+as workers to read in an N5 dataset and write it out in a multiscale Zarr dataset.
+Both datasets may be local or directly on S3. AWS credentials must be available in the
+environment (Code Ocean credential assignment to environment variables).
+
+This implementation is based on dask.array (da).
+
+This command takes a manifest json file as the only command line argument or looks it 
+up at the hard-wired `data/manifest/exaspim_manifest.json` location if not specified.
+
+To set up a code ocean capsule, use the following `run.sh` script:
+
+```bash
+#!/usr/bin/env bash
+set -ex
+cd ~/capsule
+n5tozarr_da_converter "$@"
+```
+
 
 ## Installation
 To use the software, in the root directory, run

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,18 @@ dynamic = ["version"]
 
 dependencies = [
     'argschema',
-    'psutil'
+    'pydantic',
+    'psutil',
+    # n5 to zarr conversion
+    'dask',
+    'distributed',
+    'zarr',
+    'numcodecs',
+    'aind-data-transfer[full]',
+    'aind-data-schema',
+    # missing dependencies from aind-data-transfer[full]
+    'hdf5plugin',
+    'kerchunk'
 ]
 
 [project.optional-dependencies]
@@ -37,6 +48,7 @@ where = ["src"]
 
 [project.scripts]
 aind_exaspim_pipeline = "aind_exaspim_pipeline_utils:main"
+n5tozarr_da_converter = "aind_exaspim_pipeline_utils:n5tozarr_da_converter"
 
 [tool.setuptools.dynamic]
 version = {attr = "aind_exaspim_pipeline_utils.__version__"}

--- a/src/aind_exaspim_pipeline_utils/__init__.py
+++ b/src/aind_exaspim_pipeline_utils/__init__.py
@@ -2,7 +2,9 @@
 """
 from .imagej_macros import ImagejMacros
 from .imagej_wrapper import main
+from .n5tozarr.n5tozarr_da import n5tozarr_da_converter
+from .exaspim_manifest import print_example_manifest
 
-__all__ = ["ImagejMacros", "main"]
+__all__ = ["ImagejMacros", "main", "n5tozarr_da_converter", "print_example_manifest"]
 
 __version__ = "0.2.2"

--- a/src/aind_exaspim_pipeline_utils/exaspim_manifest.py
+++ b/src/aind_exaspim_pipeline_utils/exaspim_manifest.py
@@ -1,0 +1,139 @@
+"""Manifest declaration for the exaSPIM capsules"""
+import sys
+from datetime import datetime
+from typing import Optional, Tuple
+
+from aind_data_schema.base import AindModel
+from aind_data_schema.data_description import Institution
+from aind_data_transfer.util import file_utils
+from pydantic import Field
+
+
+# Based on aind-data-transfer/scripts/processing_manifest.py
+
+
+class DatasetStatus(AindModel):  # pragma: no cover
+    """Status of the datasets to control next processing step. TBD"""
+
+    # status: Status = Field(
+    #     ...,
+    #     description="Status of the dataset on the local storage",
+    #     title="Institution",
+    #     enumNames=[i.value for i in Status],
+    # )
+    # Creating datetime
+    status_date = Field(
+        datetime.now().date().strftime("%Y-%m-%d"),
+        title="Date the flag was created",
+    )
+    status_time = Field(
+        datetime.now().time().strftime("%H-%M-%S"),
+        title="Time the flag was created",
+    )
+
+
+class N5toZarrParameters(AindModel):  # pragma: no cover
+    """N5 to zarr conversion configuration parameters.
+
+    n5tozarr_da_converter Code Ocean task config parameters."""
+    voxel_size_zyx: Tuple[float, float, float] = Field(
+        ..., title="Z,Y,X voxel size in micrometers for output metadata"
+    )
+
+    input_bucket: Optional[str] = Field(
+        None, title="The input bucket. If specified, triggers reading from S3 directly."
+    )
+
+    input_name: str = Field(
+        ...,
+        title="Input N5 dataset path. Interpreted as relative to the bucket if given, otherwise,"
+        "as a path on the local filesystem.",
+    )
+
+    output_bucket: Optional[str] = Field(
+        None, title="The output S3 bucket. If sepcified, triggers writing to S3 directly."
+    )
+
+    output_name: str = Field(
+        ...,
+        title="Input N5 dataset path. Interpreted as relative to the bucket if given, otherwise,"
+        "as a path on the local filesystem.",
+    )
+
+
+class ExaspimProcessingPipeline(AindModel):  # pragma: no cover
+    """ExaSPIM processing pipeline configuration parameters"""
+    n5_to_zarr: N5toZarrParameters = Field(..., title="N5 to multiscale Zarr conversion")
+
+
+class ExaspimManifest(AindModel):  # pragma: no cover
+    """Manifest definition of an exaSPIM processing session.
+
+    Connects the dataset and its pipeline processing history."""
+
+    schema_version: str = Field("0.1.0", title="Schema Version", const=True)
+    license: str = Field("CC-BY-4.0", title="License", const=True)
+
+    specimen_id: str = Field(..., title="Specimen ID")
+    # dataset_status: DatasetStatus = Field(
+    #     ..., title="Dataset status", description="Dataset status"
+    # )
+    institution: Institution = Field(
+        ...,
+        description="An established society, corporation, foundation or other organization "
+        "that collected this data",
+        title="Institution",
+        enumNames=[i.value.name for i in Institution],
+    )
+    # acquisition: Acquisition = Field(
+    #     ...,
+    #     title="Acquisition data",
+    #     description="Acquition data coming from the rig which is necessary to create matadata files",
+    # )
+
+    processing_pipeline: ExaspimProcessingPipeline = Field(
+        ...,
+        title="ExaSPIM pipeline parameters",
+        description="Parameters necessary for the exaspim pipeline steps.",
+    )
+
+
+def print_example_manifest():  # pragma: no cover
+    """Create example manifest file"""
+    # print(ProcessingManifest.schema_json(indent=2))
+    # print(ProcessingManifest.schema())
+
+    processing_manifest_example = ExaspimManifest(
+        specimen_id="000000",
+        institution=Institution.AIND,
+        processing_pipeline=ExaspimProcessingPipeline(
+            n5_to_zarr=N5toZarrParameters(
+                voxel_size_zyx=(1.0, 0.75, 0.75),
+                input_bucket="aind-scratch-data",
+                input_name="/gabor.kovacs/2023-07-25_1653_BSS_fusion_653431/ch561/",
+                output_bucket="aind-scratch-data",
+                output_name="/gabor.kovacs/n5_to_zarr_CO_2023-08-17_1351/",
+            )
+        ),
+    )
+
+    print(processing_manifest_example.json(indent=3))
+
+
+def get_capsule_manifest():  # pragma: no cover
+    """Get the manifest file from its Code Ocean location or as given in the cmd-line argument.
+
+    Raises
+    ------
+    If the manifest is not found, required fields will be missing at schema validation.
+    """
+    if len(sys.argv) > 1:
+        manifest_name = sys.argv[1]
+    else:
+        manifest_name = "data/manifest/exaspim_manifest.json"
+    json_data = file_utils.read_json_as_dict(manifest_name)
+    return ExaspimManifest(**json_data)
+
+
+if __name__ == "__main__":
+    print_example_manifest()

--- a/src/aind_exaspim_pipeline_utils/n5tozarr/__init__.py
+++ b/src/aind_exaspim_pipeline_utils/n5tozarr/__init__.py
@@ -1,0 +1,1 @@
+"""Module init file."""

--- a/src/aind_exaspim_pipeline_utils/n5tozarr/n5tozarr_da.py
+++ b/src/aind_exaspim_pipeline_utils/n5tozarr/n5tozarr_da.py
@@ -1,0 +1,153 @@
+"""ExaSPIM cloud conversion of N5 to multiscale ZARR using Dask.array"""
+import logging
+import multiprocessing
+from typing import Iterable, Optional, Tuple
+import time
+import dask
+import dask.array
+import zarr
+import re
+from dask.distributed import Client
+from numcodecs import Blosc
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s %(process)d %(message)s", datefmt="%Y-%m-%d %H:%M"
+)
+
+from aind_data_transfer.transformations import ome_zarr  # noqa: E402
+from aind_data_transfer.util import chunk_utils, io_utils  # noqa: E402
+from aind_exaspim_pipeline_utils import exaspim_manifest  # noqa: E402
+from aind_exaspim_pipeline_utils.exaspim_manifest import N5toZarrParameters  # noqa: E402
+
+LOGGER = logging.getLogger()
+LOGGER.setLevel(logging.INFO)
+
+
+def get_uri(bucket_name: Optional[str], *names: Iterable[str]) -> str:
+    """Format location paths by making slash usage consistent.
+
+    All multiple occurrence internal slashes are replaced to single ones.
+
+    Parameters
+    ----------
+    bucket_name: `str`, optional
+        The name of the S3 bucket. If specified, it triggers
+        the interpretation as an S3 uri.
+
+    names: Iterable of `str`
+        Path elements to connect with '/'.
+
+    Returns
+    -------
+    r: `str`
+      Formatted uri, either a local file system path or an s3:// uri.
+    """
+    if bucket_name is None:
+        s = "/".join((*names, ""))
+        return re.sub(r"/{2,}", "/", s)
+    s = "/".join(("", bucket_name, *names, ""))
+    return "s3:/" + re.sub(r"/{2,}", "/", s)
+
+
+def run_multiscale(
+        input_bucket: Optional[str],
+        input_name: str,
+        output_bucket: Optional[str],
+        output_name: str,
+        voxel_sizes_zyx: Tuple[float, float, float],
+):  # pragma: no cover
+    """Run initial conversion and 4 layers of downscaling.
+
+    All output arrays will be 5D, chunked as (1, 1, 128, 128, 128),
+    downscaling factor is (1, 1, 2, 2, 2).
+
+    Parameters
+    ----------
+    input_bucket: `str`, optional
+        Input bucket or None for local filesystem access.
+    input_name: `str`
+        Input path within bucket or on the local filesystem.
+    output_bucket: `str`, optional
+        Output bucket or None for local filesystem access.
+    output_name: `str`
+        Output path within bucket or on the local filesystem.
+    voxel_sizes_zyx: tuple of `float`
+        Voxel size in microns in the input (full resolution) dataset
+    """
+    LOGGER.debug("Initialize source N5 store")
+    n5s = zarr.n5.N5FSStore(get_uri(input_bucket, input_name))
+    zg = zarr.open(store=n5s, mode="r")
+    LOGGER.debug("Initialize dask array from N5 source")
+    arr = dask.array.from_array(zg["s0"])
+    arr = chunk_utils.ensure_array_5d(arr)
+    LOGGER.debug("Re-chunk dask array to desired output chunk size.")
+    arr = arr.rechunk((1, 1, 128, 128, 128))
+
+    LOGGER.info(f"Input array: {arr}")
+    LOGGER.info(f"Input array size: {arr.nbytes / 2 ** 20} MiB")
+
+    LOGGER.debug("Initialize target Zarr store")
+    output_path = get_uri(output_bucket, output_name)
+    group = zarr.open_group(output_path, mode="w")
+
+    scale_factors = (2, 2, 2)
+    scale_factors = chunk_utils.ensure_shape_5d(scale_factors)
+
+    n_levels = 5
+    compressor = Blosc(cname="zstd", clevel=1)
+
+    block_shape = chunk_utils.ensure_shape_5d(
+        io_utils.BlockedArrayWriter.get_block_shape(arr, target_size_mb=819200)
+    )
+    LOGGER.info(f"Calculation block shape: {block_shape}")
+
+    # Actual Processing
+    ome_zarr.write_ome_ngff_metadata(
+        group,
+        arr,
+        output_name,
+        n_levels,
+        scale_factors[2:],
+        voxel_sizes_zyx,
+        origin=None,
+    )
+
+    t0 = time.time()
+    LOGGER.info("Starting initial N5 -> Zarr copy.")
+    ome_zarr.store_array(arr, group, "0", block_shape, compressor)
+    LOGGER.info("Starting N5 -> downsampled Zarr level copies.")
+    pyramid = ome_zarr.downsample_and_store(arr, group, n_levels, scale_factors, block_shape, compressor)
+    write_time = time.time() - t0
+
+    LOGGER.info(
+        f"Finished writing tile.\n"
+        f"Took {write_time}s. {ome_zarr._get_bytes(pyramid) / write_time / (1024 ** 2)} MiB/s"
+    )
+
+
+def n5tozarr_da_converter():  # pragma: no cover
+    """Main entry point."""
+
+    config: N5toZarrParameters = exaspim_manifest.get_capsule_manifest().processing_pipeline.n5_to_zarr
+    n_cpu = multiprocessing.cpu_count()
+    LOGGER.info("Starting local Dask cluster with %d processes and 4 threads per process.", n_cpu)
+    dask.config.set(
+        {
+            "distributed.worker.memory.spill": False,  # Do not spill to /tmp space in a capsule
+            "distributed.worker.memory.target": False,  # Do not spill to /tmp space in a capsule
+            "distributed.worker.memory.terminate": False,  # Just pause and wait for GC and memory trimming
+        }
+    )
+    client = Client(n_workers=n_cpu, threads_per_worker=2)
+    run_multiscale(
+        config.input_bucket,
+        config.input_name,
+        config.output_bucket,
+        config.output_name,
+        config.voxel_size_zyx,
+    )
+    client.close(180)  # leave time for workers to exit
+
+
+if __name__ == "__main__":
+    n5tozarr_da_converter()

--- a/tests/test_n5tozarr.py
+++ b/tests/test_n5tozarr.py
@@ -1,0 +1,15 @@
+"""Tests for n5tozarr_da_convert functions."""
+import unittest
+from aind_exaspim_pipeline_utils.n5tozarr.n5tozarr_da import get_uri
+
+
+class TestN5toZarr(unittest.TestCase):
+    """N5toZarr tests"""
+
+    def test_uri_formatting(self):
+        """Uri string formatter test case"""
+        s = get_uri("test_bucket", "/zarr_root/", "dataset_name")
+        self.assertEqual(s, "s3://test_bucket/zarr_root/dataset_name/")
+
+        s = get_uri(None, "/zarr_root/", "dataset_name")
+        self.assertEqual(s, "/zarr_root/dataset_name/")


### PR DESCRIPTION
  * Update dependencies.
  * Add manifest file approach instead of command line agruments.
  * Increase block size to approx 8000 chunks.
  * The larger the graph the better the performance.
  * Reduce threads per worker to 2. Prevent memory spilling to tmp space.
  * Add minimal unit tests.
  * Code reformatting.