### PR TITLE
feat: Implement zarr multiscale conversion as separate task

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ where = ["src"]
 [project.scripts]
 aind_exaspim_pipeline = "aind_exaspim_pipeline_utils:main"
 n5tozarr_da_converter = "aind_exaspim_pipeline_utils:n5tozarr_da_converter"
+zarr_multiscale_converter = "aind_exaspim_pipeline_utils:zarr_multiscale_converter"
 
 [tool.setuptools.dynamic]
 version = {attr = "aind_exaspim_pipeline_utils.__version__"}

--- a/src/aind_exaspim_pipeline_utils/__init__.py
+++ b/src/aind_exaspim_pipeline_utils/__init__.py
@@ -2,9 +2,15 @@
 """
 from .imagej_macros import ImagejMacros
 from .imagej_wrapper import main
-from .n5tozarr.n5tozarr_da import n5tozarr_da_converter
-from .exaspim_manifest import print_example_manifest
+from .n5tozarr.n5tozarr_da import n5tozarr_da_converter, zarr_multiscale_converter
+from .exaspim_manifest import create_example_manifest
 
-__all__ = ["ImagejMacros", "main", "n5tozarr_da_converter", "print_example_manifest"]
+__all__ = [
+    "ImagejMacros",
+    "main",
+    "n5tozarr_da_converter",
+    "create_example_manifest",
+    "zarr_multiscale_converter",
+]
 
 __version__ = "0.3.1"

--- a/src/aind_exaspim_pipeline_utils/exaspim_manifest.py
+++ b/src/aind_exaspim_pipeline_utils/exaspim_manifest.py
@@ -1,8 +1,10 @@
 """Manifest declaration for the exaSPIM capsules"""
+import os
 import sys
 from datetime import datetime
 from typing import Optional, Tuple
 
+from aind_data_schema import DataProcess, Processing
 from aind_data_schema.base import AindModel
 from aind_data_schema.data_description import Institution
 from aind_data_transfer.util import file_utils
@@ -36,6 +38,7 @@ class N5toZarrParameters(AindModel):  # pragma: no cover
     """N5 to zarr conversion configuration parameters.
 
     n5tozarr_da_converter Code Ocean task config parameters."""
+
     voxel_size_zyx: Tuple[float, float, float] = Field(
         ..., title="Z,Y,X voxel size in micrometers for output metadata"
     )
@@ -61,9 +64,31 @@ class N5toZarrParameters(AindModel):  # pragma: no cover
     )
 
 
+class ZarrMultiscaleParameters(AindModel):  # pragma: no cover
+    """N5 to zarr conversion configuration parameters.
+
+    zarr_multiscale Code Ocean task config parameters."""
+
+    voxel_size_zyx: Tuple[float, float, float] = Field(
+        ..., title="Z,Y,X voxel size in micrometers for output metadata"
+    )
+
+    input_uri: str = Field(
+        ...,
+        title="Input Zarr group dataset path. Must be a local filesystem path or "
+        "start with s3:// to trigger S3 direct access.",
+    )
+
+    output_uri: Optional[str] = Field(None, title="Output Zarr group dataset path if different from input.")
+
+
 class ExaspimProcessingPipeline(AindModel):  # pragma: no cover
-    """ExaSPIM processing pipeline configuration parameters"""
-    n5_to_zarr: N5toZarrParameters = Field(..., title="N5 to multiscale Zarr conversion")
+    """ExaSPIM processing pipeline configuration parameters
+
+    If a field is None, it is considered to be a disabled step."""
+
+    n5_to_zarr: N5toZarrParameters = Field(None, title="N5 to single scale Zarr conversion")
+    zarr_multiscale: ZarrMultiscaleParameters = Field(None, title="Zarr to multiscale Zarr conversion")
 
 
 class ExaspimManifest(AindModel):  # pragma: no cover
@@ -96,15 +121,30 @@ class ExaspimManifest(AindModel):  # pragma: no cover
         title="ExaSPIM pipeline parameters",
         description="Parameters necessary for the exaspim pipeline steps.",
     )
+    processing: Processing = Field(
+        ...,
+        title="ExaSPIM pipeline processing steps log",
+        description="Processing steps that has already taken place.",
+    )
 
 
-def print_example_manifest():  # pragma: no cover
-    """Create example manifest file"""
+def create_example_manifest(printit=False) -> ExaspimManifest:  # pragma: no cover
+    """Create example manifest file
+
+    Parameters
+    ----------
+    printit: bool
+      Print the example?
+
+    Returns
+    -------
+    example_manifest: ExaspimManifest
+    """
     # print(ProcessingManifest.schema_json(indent=2))
     # print(ProcessingManifest.schema())
 
     processing_manifest_example = ExaspimManifest(
-        specimen_id="000000",
+        specimen_id="653431",
         institution=Institution.AIND,
         processing_pipeline=ExaspimProcessingPipeline(
             n5_to_zarr=N5toZarrParameters(
@@ -113,11 +153,18 @@ def print_example_manifest():  # pragma: no cover
                 input_name="/gabor.kovacs/2023-07-25_1653_BSS_fusion_653431/ch561/",
                 output_bucket="aind-scratch-data",
                 output_name="/gabor.kovacs/n5_to_zarr_CO_2023-08-17_1351/",
-            )
+            ),
+            zarr_multiscale=ZarrMultiscaleParameters(
+                voxel_size_zyx=(1.0, 0.75, 0.75),
+                input_uri="s3://aind-scratch-data/gabor.kovacs/2023-07-25_1653_BSS_fusion_653431/ch561/",
+            ),
         ),
+        processing=Processing(data_processes=[]),
     )
 
-    print(processing_manifest_example.json(indent=3))
+    if printit:
+        print(processing_manifest_example.json(indent=3))
+    return processing_manifest_example
 
 
 def get_capsule_manifest():  # pragma: no cover
@@ -135,5 +182,28 @@ def get_capsule_manifest():  # pragma: no cover
     return ExaspimManifest(**json_data)
 
 
+def append_metadata_to_manifest(capsule_manifest: ExaspimManifest, process: DataProcess) -> None:
+    """Append the given dataprocess metadata to the exaspim pipeline manifest
+
+    So long the pipeline is a linear sequence of steps, this should always be the
+    case.
+    """
+    capsule_manifest.processing.data_processes.append(process)
+
+
+def write_result_manifest(capsule_manifest: ExaspimManifest) -> None:
+    """Write the updated manifest file to the Code Ocean results folder."""
+    os.makedirs("results/manifest", exist_ok=True)
+    with open("results/manifest/exaspim_manifest.json", "w") as f:
+        f.write(capsule_manifest.json(indent=3))
+
+
+def write_result_metadata(capsule_metadata: DataProcess) -> None:
+    """Write the metadata file to the Code Ocean results folder."""
+    os.makedirs("results/meta", exist_ok=True)
+    with open("results/meta/exaspim_process.json", "w") as f:
+        f.write(capsule_metadata.json(indent=3))
+
+
 if __name__ == "__main__":
-    print_example_manifest()
+    create_example_manifest(printit=True)

--- a/src/aind_exaspim_pipeline_utils/n5tozarr/n5tozarr_da.py
+++ b/src/aind_exaspim_pipeline_utils/n5tozarr/n5tozarr_da.py
@@ -1,25 +1,37 @@
 """ExaSPIM cloud conversion of N5 to multiscale ZARR using Dask.array"""
+import datetime
 import logging
-import multiprocessing
-from typing import Iterable, Optional, Tuple
-import time
-import zarr
-import re
-from numcodecs import Blosc
 
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s %(process)d %(message)s", datefmt="%Y-%m-%d %H:%M"
-)
-LOGGER = logging.getLogger()
-LOGGER.setLevel(logging.INFO)
+import xarray_multiscale
+from aind_data_schema import DataProcess
+from aind_data_schema.processing import ProcessName
+from aind_data_transfer.transformations.ome_zarr import _get_first_mipmap_level
+from aind_data_transfer.util.io_utils import BlockedArrayWriter
+from numcodecs.abc import Codec
 
+import aind_exaspim_pipeline_utils
+from xarray_multiscale.reducers import WindowedReducer
+
+import multiprocessing  # noqa: E402
+from typing import Iterable, Optional, Tuple, Any  # noqa: E402
+import time  # noqa: E402
+import psutil  # noqa: E402
+import zarr  # noqa: E402
+import re  # noqa: E402
+from numcodecs import Blosc  # noqa: E402
 import dask  # noqa: E402
 import dask.array  # noqa: E402
 from dask.distributed import Client  # noqa: E402
 from aind_data_transfer.transformations import ome_zarr  # noqa: E402
 from aind_data_transfer.util import chunk_utils, io_utils  # noqa: E402
 from aind_exaspim_pipeline_utils import exaspim_manifest  # noqa: E402
-from aind_exaspim_pipeline_utils.exaspim_manifest import N5toZarrParameters  # noqa: E402
+from aind_exaspim_pipeline_utils.exaspim_manifest import (
+    N5toZarrParameters,
+    ZarrMultiscaleParameters,
+    write_result_metadata,
+    write_result_manifest,
+    append_metadata_to_manifest,
+)  # noqa: E402
 
 
 def get_uri(bucket_name: Optional[str], *names: Iterable[str]) -> str:
@@ -48,12 +60,86 @@ def get_uri(bucket_name: Optional[str], *names: Iterable[str]) -> str:
     return "s3:/" + re.sub(r"/{2,}", "/", s)
 
 
-def run_multiscale(
-        input_bucket: Optional[str],
-        input_name: str,
-        output_bucket: Optional[str],
-        output_name: str,
-        voxel_sizes_zyx: Tuple[float, float, float],
+def fmt_uri(uri: str) -> str:
+    """Format location paths by making slash usage consistent.
+
+    All multiple occurrence internal slashes are replaced to single ones.
+
+    Parameters
+    ----------
+    uri: `str`
+        The resource URI.
+
+    Returns
+    -------
+    r: `str`
+      Formatted uri, either a local file system path or an s3:// uri.
+    """
+    if uri.startswith("s3:") or uri.startswith("S3:"):
+        s = "/".join(("", *uri[3:].split("/"), ""))
+        return "s3:/" + re.sub(r"/{2,}", "/", s)
+    else:
+        return re.sub(r"/{2,}", "/", uri)
+
+
+def downsample_and_store(
+    arr: dask.array.Array,
+    group: zarr.Group,
+    n_lvls: int,
+    scale_factors: Tuple,
+    block_shape: Tuple,
+    compressor: Codec = None,
+    reducer: WindowedReducer = xarray_multiscale.reducers.windowed_mean,
+    fromLevel: int = 1,
+) -> list:
+    """
+    Progressively downsample the input array and store the results as separate arrays in a Zarr group.
+
+    Parameters
+    ----------
+    arr : da.Array
+        The full-resolution Dask array.
+    group : zarr.Group
+        The output Zarr group.
+    n_lvls : int
+        The number of pyramid levels.
+    scale_factors : Tuple
+        The scale factors for downsampling along each dimension.
+    block_shape : Tuple
+        The shape of blocks to use for partitioning the array.
+    compressor : numcodecs.abc.Codec, optional
+        The compression codec to use for the output Zarr array. Default is Blosc with "zstd" method and compression
+        level 1.
+    fromLevel : int
+        The first downscaled level to write. `arr` must represent fromLevel - 1. Defaults to 1.
+    """
+
+    for arr_index in range(fromLevel, n_lvls):
+        LOGGER.info("Creating downsampled level %d in dask.", arr_index)
+        first_mipmap = _get_first_mipmap_level(arr, scale_factors, reducer)
+
+        LOGGER.info("Creating dataset for level %d.", arr_index)
+        ds = group.create_dataset(
+            str(arr_index),
+            shape=first_mipmap.shape,
+            chunks=first_mipmap.chunksize,
+            dtype=first_mipmap.dtype,
+            compressor=compressor,
+            dimension_separator="/",
+            overwrite=True,
+        )
+        LOGGER.info("Storing downsampled level %d.", arr_index)
+        BlockedArrayWriter.store(first_mipmap, ds, block_shape)
+
+        arr = dask.array.from_array(ds, ds.chunks)
+
+
+def run_n5tozarr(
+    input_bucket: Optional[str],
+    input_name: str,
+    output_bucket: Optional[str],
+    output_name: str,
+    voxel_sizes_zyx: Tuple[float, float, float],
 ):  # pragma: no cover
     """Run initial conversion and 4 layers of downscaling.
 
@@ -114,38 +200,258 @@ def run_multiscale(
     t0 = time.time()
     LOGGER.info("Starting initial N5 -> Zarr copy.")
     ome_zarr.store_array(arr, group, "0", block_shape, compressor)
+    write_time = time.time() - t0
+    LOGGER.info(f"Finished writing tile. Took {write_time}s.")
+
+
+def run_zarr_multiscale(
+    input_uri: str, output_uri: str, voxel_sizes_zyx: Tuple[float, float, float], fromLevel: int = 1
+):  # pragma: no cover
+    """Run downscaling on an existing 0 level zarr.
+
+    All output arrays will be 5D, chunked as (1, 1, 128, 128, 128),
+    downscaling factor is (1, 1, 2, 2, 2).
+
+    Parameters
+    ----------
+    input_uri: `str`
+        Input s3 uri path or path on the local filesystem.
+    output_uri: `str`
+        Output s3 uri path or path on the local filesystem.
+    voxel_sizes_zyx: tuple of `float`
+        Voxel size in microns in the input (full resolution) dataset
+    """
+    LOGGER.debug("Initialize source Zarr store")
+    zg = zarr.open_group(input_uri, mode="r")
+    LOGGER.info("Get dask array from Zarr source for full resolution")
+    arrZero = dask.array.from_array(zg["0"])  # For metadata writing we need the full resolution shape
+    arrZero = chunk_utils.ensure_array_5d(arrZero)
+    arrZero = arrZero.rechunk((1, 1, 128, 128, 128))
+
+    LOGGER.info(f"Full resolution array: {arrZero}")
+    LOGGER.info(f"Full resolution input array size: {arrZero.nbytes / 2 ** 20} MiB")
+
+    LOGGER.debug("Initialize target Zarr store")
+    group = zarr.open_group(output_uri, mode="a")
+
+    scale_factors = (2, 2, 2)
+    scale_factors = chunk_utils.ensure_shape_5d(scale_factors)
+
+    n_levels = 8
+    compressor = Blosc(cname="zstd", clevel=1)
+
+    # Actual Processing
+    ome_zarr.write_ome_ngff_metadata(
+        group,
+        arrZero,
+        output_uri,
+        n_levels,
+        scale_factors[2:],
+        voxel_sizes_zyx,
+        origin=None,
+    )
+
+    if fromLevel > 1:
+        prevLevel = str(fromLevel - 1)
+        LOGGER.info("Initialize dask source array from Zarr source level %s", prevLevel)
+        arr = dask.array.from_array(zg[prevLevel])
+        arr = chunk_utils.ensure_array_5d(arr)
+        arr = arr.rechunk((1, 1, 128, 128, 128))
+    else:
+        arr = arrZero
+
+    del arrZero  # Can be garbage collected if different from arr
+
+    block_shape = chunk_utils.ensure_shape_5d(
+        io_utils.BlockedArrayWriter.get_block_shape(arr, target_size_mb=64000)
+    )
+    LOGGER.info(f"Calculation block shape: {block_shape}")
+
+    t0 = time.time()
     LOGGER.info("Starting N5 -> downsampled Zarr level copies.")
-    pyramid = ome_zarr.downsample_and_store(arr, group, n_levels, scale_factors, block_shape, compressor)
+    downsample_and_store(arr, group, n_levels, scale_factors, block_shape, compressor, fromLevel=fromLevel)
     write_time = time.time() - t0
 
-    LOGGER.info(
-        f"Finished writing tile.\n"
-        f"Took {write_time}s. {ome_zarr._get_bytes(pyramid) / write_time / (1024 ** 2)} MiB/s"
-    )
+    LOGGER.info(f"Finished writing tile. Took %d s.", write_time)
+
+
+def get_worker_memory(n_worker):
+    """Determine the per-worker memory"""
+    total = psutil.virtual_memory().total
+    GByte = 1024 * 1024 * 1024
+    LOGGER.info("Total physical memory: %.1f GiB", total / GByte)
+    wmem = total - 24 * GByte  # Reserve for scheduler
+    perworker = wmem // n_worker
+    if wmem < 0 or perworker < 2 * GByte:
+        raise RuntimeError("Not enough memory for 24 GiB for scheduler and at least 2 GiB per worker")
+    LOGGER.info("Set aside 24 GiB for scheduler, %.1f GiB per worker process", perworker / GByte)
+    return perworker
+
+
+def config_logging(level: int = logging.DEBUG):
+    """Configure logging on a worker or the client."""
+    config = {
+        "version": 1,
+        "handlers": {
+            "console": {
+                "class": "logging.StreamHandler",
+                "formatter": "default",
+                "level": logging.getLevelName(level),
+            }
+        },
+        "formatters": {
+            "default": {
+                # "worker" field was referenced in `Client.forward_logging` documentation but does not work:
+                # "format": "%(asctime)s %(levelname)-8s [%(process)d %(worker)s] %(name)-15s %(message)s",
+                "format": "%(asctime)s [%(process)d] %(levelname)s %(name)s %(message)s",
+                "datefmt": "%Y-%m-%d %H:%M:%S",
+            }
+        },
+        "root": {"handlers": ["console"]},
+    }
+    logging.config.dictConfig(config)
+    logging.getLogger().setLevel(level)
+    logging.getLogger("distributed").setLevel(level)
+    # Do not want to see network debug stuff
+    if level > logging.INFO:
+        infolevel = level
+    else:
+        infolevel = logging.INFO
+    logging.getLogger("boto3").setLevel(infolevel)
+    logging.getLogger("botocore").setLevel(infolevel)
+    logging.getLogger("s3fs").setLevel(infolevel)
+    logging.getLogger("urllib3").setLevel(infolevel)
 
 
 def n5tozarr_da_converter():  # pragma: no cover
     """Main entry point."""
-
+    config_logging(logging.DEBUG)
     config: N5toZarrParameters = exaspim_manifest.get_capsule_manifest().processing_pipeline.n5_to_zarr
     n_cpu = multiprocessing.cpu_count()
+
     LOGGER.info("Starting local Dask cluster with %d processes and 2 threads per process.", n_cpu)
     dask.config.set(
         {
             "distributed.worker.memory.spill": False,  # Do not spill to /tmp space in a capsule
             "distributed.worker.memory.target": False,  # Do not spill to /tmp space in a capsule
             "distributed.worker.memory.terminate": False,  # Just pause and wait for GC and memory trimming
+            "distributed.worker.memory.pause": 0.70,  # Pause at 70% of worker memory usage
         }
     )
-    client = Client(n_workers=n_cpu, threads_per_worker=2)
-    run_multiscale(
+    client = Client(
+        n_workers=n_cpu,
+        threads_per_worker=2,
+        memory_limit=get_worker_memory(n_cpu),
+        processes=True,
+        silence_logs=False,
+    )
+    client.run(config_logging, logging.DEBUG)
+    client.forward_logging()
+
+    run_n5tozarr(
         config.input_bucket,
         config.input_name,
         config.output_bucket,
         config.output_name,
         config.voxel_size_zyx,
     )
+    # Close down
+    LOGGER.info("Sleep 120s to get workers into an idle state.")
+    time.sleep(120)  # leave time for workers to get into an idle state before shutting down
+    LOGGER.info("Closing cluster.")
     client.close(180)  # leave time for workers to exit
+
+
+def get_zarr_multiscale_metadata(config: dict):
+    t = datetime.datetime.now()
+    dp = DataProcess(
+        name=ProcessName.FILE_CONVERSION,
+        version=config["capsule"]["version"],
+        start_date_time=t,
+        end_date_time=t,
+        input_location=config["input_uri"],
+        output_location=config["output_uri"],
+        code_url="https://github.com/AllenNeuralDynamics/aind-exaSPIM-pipeline-utils",
+        code_version=aind_exaspim_pipeline_utils.__version__,
+        parameters=config,
+        outputs=None,
+        notes="IN PROGRESS",
+    )
+    return dp
+
+
+def set_metadata_done(meta: DataProcess) -> None:  # pragma: no cover
+    """Update end timestamp and set metadata note to ``DONE``.
+
+    Parameters
+    ----------
+    meta: DataProcess
+      Capsule metadata instance.
+    """
+    t = datetime.datetime.now()
+    meta.end_date_time = t
+    meta.notes = "DONE"
+
+
+def zarr_multiscale_converter():  # pragma: no cover
+    """Main entry point for zarr downscaling task."""
+    config_logging()
+    global LOGGER
+    LOGGER = logging.getLogger("zarr_mscale")
+    LOGGER.setLevel(logging.DEBUG)
+
+    capsule_manifest = exaspim_manifest.get_capsule_manifest()
+    config = capsule_manifest.processing_pipeline.zarr_multiscale.dict()
+    if config is None:
+        raise ValueError("Manifest does not contain configuration for zarr_multiscale parameters")
+
+    # Add dynamic entries to config
+    config["input_uri"] = fmt_uri(config["input_uri"])
+    if config["output_uri"] is None:
+        config["output_uri"] = config["input_uri"]
+    else:
+        config["output_uri"] = fmt_uri(config["output_uri"])
+    n_cpu = multiprocessing.cpu_count()
+    config["capsule"] = dict(
+        version="zarr_multiscale_0.1.0", n_cpu=n_cpu
+    )  # TBD: obtain version from CO environment
+
+    # Create initial metadata in case the run crashes
+    meta = get_zarr_multiscale_metadata(config)
+    write_result_metadata(meta)
+
+    # Start dask cluster
+    LOGGER.info("Starting local Dask cluster with %d processes and 2 threads per process.", n_cpu)
+    dask.config.set(
+        {
+            "distributed.worker.memory.spill": False,  # Do not spill to /tmp space in a capsule
+            "distributed.worker.memory.target": False,  # Do not spill to /tmp space in a capsule
+            "distributed.worker.memory.terminate": False,  # Just pause and wait for GC and memory trimming
+            "distributed.worker.memory.pause": 0.70,  # Pause at 70% of worker memory usage
+        }
+    )
+    client = Client(
+        n_workers=n_cpu,
+        threads_per_worker=2,
+        memory_limit=get_worker_memory(n_cpu),
+        processes=True,
+        silence_logs=logging.DEBUG,
+    )
+    client.run(config_logging, logging.DEBUG)
+    client.forward_logging()
+    # Run jobs
+    run_zarr_multiscale(config["input_uri"], config["output_uri"], config["voxel_size_zyx"])
+    # Update metadata to show that we've finished properly
+    set_metadata_done(meta)
+    write_result_metadata(meta)
+    append_metadata_to_manifest(capsule_manifest, meta)
+    write_result_manifest(capsule_manifest)
+    # Close down
+    LOGGER.info("Sleep 120s to get workers into an idle state.")
+    time.sleep(120)  # leave time for workers to get into an idle state before shutting down
+    LOGGER.info("Closing cluster.")
+    client.close(180)  # leave time for workers to exit
+    LOGGER.info("Done.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
 * Split n5 to zarr conversion and zarr multiscale conversion as separate tasks.
 * Update logging, configure logging on workers.
 * Add manifest file input and output.
 * Add processing metadata output.
 * Add support to add further zarr downscaling levels.
 * Reduce working block size to 64GB.