### PR TITLE
feat: N5tozarr manifest update. Logger settings, Dask input chunk size match, working block size.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,11 @@ dependencies = [
     'zarr',
     'numcodecs',
     'aind-data-transfer[full]',
-    'aind-data-schema',
+    'aind-data-schema'
     # missing dependencies from aind-data-transfer[full]
-    'hdf5plugin',
-    'kerchunk'
+    # These supposed to be installed by post_install.sh
+#    'hdf5plugin',
+#    'kerchunk'
 ]
 
 [project.optional-dependencies]

--- a/src/aind_exaspim_pipeline_utils/exaspim_manifest.py
+++ b/src/aind_exaspim_pipeline_utils/exaspim_manifest.py
@@ -43,24 +43,17 @@ class N5toZarrParameters(AindModel):  # pragma: no cover
         ..., title="Z,Y,X voxel size in micrometers for output metadata"
     )
 
-    input_bucket: Optional[str] = Field(
-        None, title="The input bucket. If specified, triggers reading from S3 directly."
-    )
-
-    input_name: str = Field(
+    input_uri: str = Field(
         ...,
-        title="Input N5 dataset path. Interpreted as relative to the bucket if given, otherwise,"
-        "as a path on the local filesystem.",
+        title="Input N5 dataset path. Must be a local filesystem path or "
+        "start with s3:// to trigger S3 direct access.",
     )
 
-    output_bucket: Optional[str] = Field(
-        None, title="The output S3 bucket. If sepcified, triggers writing to S3 directly."
-    )
-
-    output_name: str = Field(
+    output_uri: str = Field(
         ...,
-        title="Input N5 dataset path. Interpreted as relative to the bucket if given, otherwise,"
-        "as a path on the local filesystem.",
+        title="Output Zarr dataset path. Must be a local filesystem path or "
+        "start with s3:// to trigger S3 direct access. "
+        "Must be different from the input_uri. Will be overwritten if exists.",
     )
 
 
@@ -148,14 +141,12 @@ def create_example_manifest(printit=False) -> ExaspimManifest:  # pragma: no cov
         institution=Institution.AIND,
         processing_pipeline=ExaspimProcessingPipeline(
             n5_to_zarr=N5toZarrParameters(
-                voxel_size_zyx=(1.0, 0.75, 0.75),
-                input_bucket="aind-scratch-data",
-                input_name="/gabor.kovacs/2023-07-25_1653_BSS_fusion_653431/ch561/",
-                output_bucket="aind-scratch-data",
-                output_name="/gabor.kovacs/n5_to_zarr_CO_2023-08-17_1351/",
+                voxel_size_zyx=(1.0, 0.748, 0.748),
+                input_uri="s3://aind-scratch-data/gabor.kovacs/2023-07-25_1653_BSS_fusion_653431/ch561/",
+                output_uri="s3://aind-scratch-data/gabor.kovacs/n5_to_zarr_CO_2023-08-17_1351/",
             ),
             zarr_multiscale=ZarrMultiscaleParameters(
-                voxel_size_zyx=(1.0, 0.75, 0.75),
+                voxel_size_zyx=(1.0, 0.748, 0.748),
                 input_uri="s3://aind-scratch-data/gabor.kovacs/2023-07-25_1653_BSS_fusion_653431/ch561/",
             ),
         ),

--- a/src/aind_exaspim_pipeline_utils/n5tozarr/n5tozarr_da.py
+++ b/src/aind_exaspim_pipeline_utils/n5tozarr/n5tozarr_da.py
@@ -1,6 +1,7 @@
 """ExaSPIM cloud conversion of N5 to multiscale ZARR using Dask.array"""
 import datetime
 import logging
+import sys
 
 import xarray_multiscale
 from aind_data_schema import DataProcess
@@ -12,58 +13,34 @@ from numcodecs.abc import Codec
 import aind_exaspim_pipeline_utils
 from xarray_multiscale.reducers import WindowedReducer
 
-import multiprocessing  # noqa: E402
-from typing import Iterable, Optional, Tuple, Any  # noqa: E402
-import time  # noqa: E402
-import psutil  # noqa: E402
-import zarr  # noqa: E402
-import re  # noqa: E402
-from numcodecs import Blosc  # noqa: E402
-import dask  # noqa: E402
-import dask.array  # noqa: E402
-from dask.distributed import Client  # noqa: E402
-from aind_data_transfer.transformations import ome_zarr  # noqa: E402
-from aind_data_transfer.util import chunk_utils, io_utils  # noqa: E402
-from aind_exaspim_pipeline_utils import exaspim_manifest  # noqa: E402
+import multiprocessing
+from typing import Tuple
+import time
+import psutil
+import zarr
+import re
+from numcodecs import Blosc
+import dask
+import dask.array
+from dask.distributed import Client
+from aind_data_transfer.transformations import ome_zarr
+from aind_data_transfer.util import chunk_utils, io_utils
+from aind_exaspim_pipeline_utils import exaspim_manifest
 from aind_exaspim_pipeline_utils.exaspim_manifest import (
-    N5toZarrParameters,
-    ZarrMultiscaleParameters,
     write_result_metadata,
     write_result_manifest,
     append_metadata_to_manifest,
-)  # noqa: E402
-
-
-def get_uri(bucket_name: Optional[str], *names: Iterable[str]) -> str:
-    """Format location paths by making slash usage consistent.
-
-    All multiple occurrence internal slashes are replaced to single ones.
-
-    Parameters
-    ----------
-    bucket_name: `str`, optional
-        The name of the S3 bucket. If specified, it triggers
-        the interpretation as an S3 uri.
-
-    names: Iterable of `str`
-        Path elements to connect with '/'.
-
-    Returns
-    -------
-    r: `str`
-      Formatted uri, either a local file system path or an s3:// uri.
-    """
-    if bucket_name is None:
-        s = "/".join((*names, ""))
-        return re.sub(r"/{2,}", "/", s)
-    s = "/".join(("", bucket_name, *names, ""))
-    return "s3:/" + re.sub(r"/{2,}", "/", s)
+)
 
 
 def fmt_uri(uri: str) -> str:
     """Format location paths by making slash usage consistent.
 
     All multiple occurrence internal slashes are replaced to single ones.
+
+    Local paths can be relative or absolute, trailing slash will be added if missing.
+
+    S3 references formatted to pattern ``s3://bucket/path/``.
 
     Parameters
     ----------
@@ -131,14 +108,12 @@ def downsample_and_store(
         LOGGER.info("Storing downsampled level %d.", arr_index)
         BlockedArrayWriter.store(first_mipmap, ds, block_shape)
 
-        arr = dask.array.from_array(ds, ds.chunks)
+        arr = dask.array.from_array(ds, chunks=ds.chunks)
 
 
 def run_n5tozarr(
-    input_bucket: Optional[str],
-    input_name: str,
-    output_bucket: Optional[str],
-    output_name: str,
+    input_uri: str,
+    output_uri: str,
     voxel_sizes_zyx: Tuple[float, float, float],
 ):  # pragma: no cover
     """Run initial conversion and 4 layers of downscaling.
@@ -148,41 +123,37 @@ def run_n5tozarr(
 
     Parameters
     ----------
-    input_bucket: `str`, optional
-        Input bucket or None for local filesystem access.
-    input_name: `str`
-        Input path within bucket or on the local filesystem.
-    output_bucket: `str`, optional
-        Output bucket or None for local filesystem access.
-    output_name: `str`
-        Output path within bucket or on the local filesystem.
+    input_uri: `str`
+        Input uri or path on the local filesystem.
+    output_uri: `str`
+        Output uri or on the local filesystem.
     voxel_sizes_zyx: tuple of `float`
         Voxel size in microns in the input (full resolution) dataset
     """
     LOGGER.debug("Initialize source N5 store")
-    n5s = zarr.n5.N5FSStore(get_uri(input_bucket, input_name))
+    n5s = zarr.n5.N5FSStore(input_uri)
     zg = zarr.open(store=n5s, mode="r")
     LOGGER.debug("Initialize dask array from N5 source")
-    arr = dask.array.from_array(zg["s0"])
+    arr = dask.array.from_array(zg["s0"], chunks=zg["s0"].chunks)
     arr = chunk_utils.ensure_array_5d(arr)
     LOGGER.debug("Re-chunk dask array to desired output chunk size.")
-    arr = arr.rechunk((1, 1, 128, 128, 128))
+    arr = arr.rechunk((1, 1, 256, 256, 256))
 
     LOGGER.info(f"Input array: {arr}")
     LOGGER.info(f"Input array size: {arr.nbytes / 2 ** 20} MiB")
 
     LOGGER.debug("Initialize target Zarr store")
-    output_path = get_uri(output_bucket, output_name)
-    group = zarr.open_group(output_path, mode="w")
+    output_path = output_uri
+    group = zarr.open_group(output_path, mode="a")
 
     scale_factors = (2, 2, 2)
     scale_factors = chunk_utils.ensure_shape_5d(scale_factors)
 
-    n_levels = 5
+    n_levels = 1
     compressor = Blosc(cname="zstd", clevel=1)
 
     block_shape = chunk_utils.ensure_shape_5d(
-        io_utils.BlockedArrayWriter.get_block_shape(arr, target_size_mb=819200)
+        io_utils.BlockedArrayWriter.get_block_shape(arr, target_size_mb=1048576)  # 8k**3 blocks of 16bit data
     )
     LOGGER.info(f"Calculation block shape: {block_shape}")
 
@@ -190,7 +161,7 @@ def run_n5tozarr(
     ome_zarr.write_ome_ngff_metadata(
         group,
         arr,
-        output_name,
+        output_uri,
         n_levels,
         scale_factors[2:],
         voxel_sizes_zyx,
@@ -217,16 +188,16 @@ def run_zarr_multiscale(
     input_uri: `str`
         Input s3 uri path or path on the local filesystem.
     output_uri: `str`
-        Output s3 uri path or path on the local filesystem.
+        Output s3 uri path or path on the local filesystem. Can be the same as `input_uri`.
     voxel_sizes_zyx: tuple of `float`
         Voxel size in microns in the input (full resolution) dataset
     """
     LOGGER.debug("Initialize source Zarr store")
     zg = zarr.open_group(input_uri, mode="r")
     LOGGER.info("Get dask array from Zarr source for full resolution")
-    arrZero = dask.array.from_array(zg["0"])  # For metadata writing we need the full resolution shape
+    arrZero = dask.array.from_array(zg["0"], chunks=zg["0"].chunks)  # For metadata writing we need the full resolution shape
     arrZero = chunk_utils.ensure_array_5d(arrZero)
-    arrZero = arrZero.rechunk((1, 1, 128, 128, 128))
+    arrZero = arrZero.rechunk((1, 1, 256, 256, 256))
 
     LOGGER.info(f"Full resolution array: {arrZero}")
     LOGGER.info(f"Full resolution input array size: {arrZero.nbytes / 2 ** 20} MiB")
@@ -254,16 +225,16 @@ def run_zarr_multiscale(
     if fromLevel > 1:
         prevLevel = str(fromLevel - 1)
         LOGGER.info("Initialize dask source array from Zarr source level %s", prevLevel)
-        arr = dask.array.from_array(zg[prevLevel])
+        arr = dask.array.from_array(zg[prevLevel], chunks=zg[prevLevel].chunks)
         arr = chunk_utils.ensure_array_5d(arr)
-        arr = arr.rechunk((1, 1, 128, 128, 128))
+        arr = arr.rechunk((1, 1, 256, 256, 256))
     else:
         arr = arrZero
 
     del arrZero  # Can be garbage collected if different from arr
 
     block_shape = chunk_utils.ensure_shape_5d(
-        io_utils.BlockedArrayWriter.get_block_shape(arr, target_size_mb=64000)
+        io_utils.BlockedArrayWriter.get_block_shape(arr, target_size_mb=1048576)  # 8k**3 blocks of 16bit data
     )
     LOGGER.info(f"Calculation block shape: {block_shape}")
 
@@ -288,28 +259,8 @@ def get_worker_memory(n_worker):
     return perworker
 
 
-def config_logging(level: int = logging.DEBUG):
-    """Configure logging on a worker or the client."""
-    config = {
-        "version": 1,
-        "handlers": {
-            "console": {
-                "class": "logging.StreamHandler",
-                "formatter": "default",
-                "level": logging.getLevelName(level),
-            }
-        },
-        "formatters": {
-            "default": {
-                # "worker" field was referenced in `Client.forward_logging` documentation but does not work:
-                # "format": "%(asctime)s %(levelname)-8s [%(process)d %(worker)s] %(name)-15s %(message)s",
-                "format": "%(asctime)s [%(process)d] %(levelname)s %(name)s %(message)s",
-                "datefmt": "%Y-%m-%d %H:%M:%S",
-            }
-        },
-        "root": {"handlers": ["console"]},
-    }
-    logging.config.dictConfig(config)
+def set_worker_logging(level: int = logging.DEBUG):
+    """Configure logger levels on a worker."""
     logging.getLogger().setLevel(level)
     logging.getLogger("distributed").setLevel(level)
     # Do not want to see network debug stuff
@@ -323,19 +274,84 @@ def config_logging(level: int = logging.DEBUG):
     logging.getLogger("urllib3").setLevel(infolevel)
 
 
+def config_client_logging(level: int = logging.DEBUG):
+    """Configure logging on a worker or the client."""
+    # config = {
+    #     "version": 1,
+    #     "handlers": {
+    #         "console": {
+    #             "class": "logging.StreamHandler",
+    #             "formatter": "default",
+    #             "level": logging.getLevelName(level),
+    #         }
+    #     },
+    #     "formatters": {
+    #         "default": {
+    #             # "worker" field was referenced in `Client.forward_logging` documentation but does not work:
+    #             # "format": "%(asctime)s %(levelname)-8s [%(process)d %(worker)s] %(name)-15s %(message)s",
+    #             "format": "%(asctime)s [%(process)d] %(levelname)s %(name)s %(message)s",
+    #             "datefmt": "%Y-%m-%d %H:%M:%S",
+    #         }
+    #     },
+    #     "root": {"handlers": ["console"]},
+    # }
+    R = logging.getLogger()
+    for hdlr in R.handlers[:]:  # remove all old handlers
+        R.removeHandler(hdlr)
+        
+    h1 = logging.StreamHandler(sys.stderr)
+    h1.setFormatter(logging.Formatter("%(asctime)s [%(process)d] %(levelname)s %(name)s %(message)s"))
+    logging.getLogger().setLevel(level)
+    logging.getLogger().addHandler(h1)
+    # logging.config.dictConfig(config)
+    # logging.getLogger().setLevel(level)
+    # Do not want to see network debug stuff
+    if level > logging.INFO:
+        infolevel = level
+    else:
+        infolevel = logging.INFO
+    logging.getLogger("distributed.worker").setLevel(infolevel)
+    logging.getLogger("distributed").setLevel(infolevel)
+    logging.getLogger("boto3").setLevel(infolevel)
+    logging.getLogger("botocore").setLevel(infolevel)
+    logging.getLogger("s3fs").setLevel(infolevel)
+    logging.getLogger("urllib3").setLevel(infolevel)
+
+
 def n5tozarr_da_converter():  # pragma: no cover
-    """Main entry point."""
-    config_logging(logging.DEBUG)
-    config: N5toZarrParameters = exaspim_manifest.get_capsule_manifest().processing_pipeline.n5_to_zarr
+    """Main entry point to n5tozarr converter task."""
+    config_client_logging(logging.INFO)
+    global LOGGER
+    LOGGER = logging.getLogger("n5tozarr")
+    LOGGER.setLevel(logging.INFO)
+
+    capsule_manifest = exaspim_manifest.get_capsule_manifest()
+    config = capsule_manifest.processing_pipeline.n5_to_zarr.dict()
+    if config is None:
+        raise ValueError("Manifest does not contain configuration for n5tozarr processing")
+
+    config["input_uri"] = fmt_uri(config["input_uri"])
+    config["output_uri"] = fmt_uri(config["output_uri"])
     n_cpu = multiprocessing.cpu_count()
 
+    config["capsule"] = dict(version="n5tozarr_0.1.0", n_cpu=n_cpu)  # TBD: obtain version from CO environment
+
+    # Create initial metadata in case the run crashes
+    meta = get_n5tozarr_metadata(config)
+    write_result_metadata(meta)
+
+    # Start dask cluster
     LOGGER.info("Starting local Dask cluster with %d processes and 2 threads per process.", n_cpu)
     dask.config.set(
         {
             "distributed.worker.memory.spill": False,  # Do not spill to /tmp space in a capsule
             "distributed.worker.memory.target": False,  # Do not spill to /tmp space in a capsule
-            "distributed.worker.memory.terminate": False,  # Just pause and wait for GC and memory trimming
-            "distributed.worker.memory.pause": 0.70,  # Pause at 70% of worker memory usage
+            # After the recent-to-old waiting, we hope that a paused state will cross this and we restart
+            # the worker
+            "distributed.worker.memory.terminate": 0.95,
+            "distributed.worker.memory.pause": 0.94,  # Just pause and wait for task finish then GC and trimming
+            "distributed.worker.memory.rebalance.recipient-max": 0.05,  # Do not receive data from other workers
+            "distributed.worker.memory.recent-to-old-time": '300s' # Should be longer than typical task runtime
         }
     )
     client = Client(
@@ -343,26 +359,44 @@ def n5tozarr_da_converter():  # pragma: no cover
         threads_per_worker=2,
         memory_limit=get_worker_memory(n_cpu),
         processes=True,
-        silence_logs=False,
+        silence_logs=logging.INFO,
     )
-    client.run(config_logging, logging.DEBUG)
+    client.run(set_worker_logging, logging.INFO)
     client.forward_logging()
-
-    run_n5tozarr(
-        config.input_bucket,
-        config.input_name,
-        config.output_bucket,
-        config.output_name,
-        config.voxel_size_zyx,
-    )
+    # Run jobs
+    run_n5tozarr(config["input_uri"], config["output_uri"], config["voxel_size_zyx"])
+    # Update metadata to show that we've finished properly
+    set_metadata_done(meta)
+    write_result_metadata(meta)
+    append_metadata_to_manifest(capsule_manifest, meta)
+    write_result_manifest(capsule_manifest)
     # Close down
     LOGGER.info("Sleep 120s to get workers into an idle state.")
     time.sleep(120)  # leave time for workers to get into an idle state before shutting down
     LOGGER.info("Closing cluster.")
     client.close(180)  # leave time for workers to exit
+    LOGGER.info("Done.")
 
 
 def get_zarr_multiscale_metadata(config: dict):
+    t = datetime.datetime.now()
+    dp = DataProcess(
+        name=ProcessName.FILE_CONVERSION,
+        version=config["capsule"]["version"],
+        start_date_time=t,
+        end_date_time=t,
+        input_location=config["input_uri"],
+        output_location=config["output_uri"],
+        code_url="https://github.com/AllenNeuralDynamics/aind-exaSPIM-pipeline-utils",
+        code_version=aind_exaspim_pipeline_utils.__version__,
+        parameters=config,
+        outputs=None,
+        notes="IN PROGRESS",
+    )
+    return dp
+
+
+def get_n5tozarr_metadata(config: dict):
     t = datetime.datetime.now()
     dp = DataProcess(
         name=ProcessName.FILE_CONVERSION,
@@ -395,7 +429,7 @@ def set_metadata_done(meta: DataProcess) -> None:  # pragma: no cover
 
 def zarr_multiscale_converter():  # pragma: no cover
     """Main entry point for zarr downscaling task."""
-    config_logging()
+    config_client_logging()
     global LOGGER
     LOGGER = logging.getLogger("zarr_mscale")
     LOGGER.setLevel(logging.DEBUG)
@@ -403,7 +437,7 @@ def zarr_multiscale_converter():  # pragma: no cover
     capsule_manifest = exaspim_manifest.get_capsule_manifest()
     config = capsule_manifest.processing_pipeline.zarr_multiscale.dict()
     if config is None:
-        raise ValueError("Manifest does not contain configuration for zarr_multiscale parameters")
+        raise ValueError("Manifest does not contain configuration for zarr_multiscale processing")
 
     # Add dynamic entries to config
     config["input_uri"] = fmt_uri(config["input_uri"])
@@ -426,8 +460,10 @@ def zarr_multiscale_converter():  # pragma: no cover
         {
             "distributed.worker.memory.spill": False,  # Do not spill to /tmp space in a capsule
             "distributed.worker.memory.target": False,  # Do not spill to /tmp space in a capsule
-            "distributed.worker.memory.terminate": False,  # Just pause and wait for GC and memory trimming
-            "distributed.worker.memory.pause": 0.70,  # Pause at 70% of worker memory usage
+            "distributed.worker.memory.terminate": 0.95,  # Just pause and wait for GC and memory trimming
+            "distributed.worker.memory.pause": 0.93,  # Pause at 93% of worker memory usage (no new jobs)
+            "distributed.worker.memory.rebalance.recipient-max": 0.1,  # Do not receive data from other workers
+            "distributed.worker.memory.recent-to-old-time": '300s' # Should be longer than typical task runtime
         }
     )
     client = Client(
@@ -437,7 +473,7 @@ def zarr_multiscale_converter():  # pragma: no cover
         processes=True,
         silence_logs=logging.DEBUG,
     )
-    client.run(config_logging, logging.DEBUG)
+    client.run(set_worker_logging, logging.DEBUG)
     client.forward_logging()
     # Run jobs
     run_zarr_multiscale(config["input_uri"], config["output_uri"], config["voxel_size_zyx"])

--- a/tests/test_n5tozarr.py
+++ b/tests/test_n5tozarr.py
@@ -1,6 +1,6 @@
 """Tests for n5tozarr_da_convert functions."""
 import unittest
-from aind_exaspim_pipeline_utils.n5tozarr.n5tozarr_da import get_uri
+from aind_exaspim_pipeline_utils.n5tozarr.n5tozarr_da import fmt_uri
 
 
 class TestN5toZarr(unittest.TestCase):
@@ -8,8 +8,8 @@ class TestN5toZarr(unittest.TestCase):
 
     def test_uri_formatting(self):
         """Uri string formatter test case"""
-        s = get_uri("test_bucket", "/zarr_root/", "dataset_name")
+        s = fmt_uri("s3:/test_bucket/zarr_root/dataset_name")
         self.assertEqual(s, "s3://test_bucket/zarr_root/dataset_name/")
 
-        s = get_uri(None, "/zarr_root/", "dataset_name")
+        s = fmt_uri("/zarr_root/dataset_name")
         self.assertEqual(s, "/zarr_root/dataset_name/")


### PR DESCRIPTION

 * Refactor n5tozarr manifest entries. Do not reconfigure worker loggers just set levels. Update n5tozarr with new manifest.
 * Remove post_install.sh dependencies. Remove import noqa exclusions.
 * Changed default voxelsize to 0.748 and reduced distributed log level to INFO on client.
 * Change default chunksize to 256 cubed. Add input chunk size to dask.
 * Set default logging to info.
 * Increase blocksize to 8k cubed. Write zarr metadata as 1 level initially.