### PR TITLE
feat: Refactor ImageJ configuration. Add trigger_capsule for automation.

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -19,8 +19,10 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
-      run: | 
+      run: |
         python -m pip install -e .[dev]
+        python -m pip install "git+https://github.com/fsspec/kerchunk"
+        python -m pip install hdf5plugin
     - name: Run linter checks
       run: flake8 . && interrogate --verbose .
     - name: Run tests and coverage

--- a/README.md
+++ b/README.md
@@ -19,7 +19,10 @@ the package if the whole package is invoked on the command line or the
 `aind_exaspim_pipeline` command is run.
 
 ```bash
-python -m aind_exaspim_pipeline_utils
+#!/usr/bin/env bash
+set -ex
+cd ~/capsule
+imagej_wrapper "$@"
 ```
 
 ### N5 to Zarr converter
@@ -53,6 +56,11 @@ pip install -e .
 To develop the code, run
 ```bash
 pip install -e .[dev]
+```
+
+For n5tozarr and zarr multiscale conversion, install as
+```bash
+pip install -e .[n5tozarr]
 ```
 
 ## Contributing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,10 +21,12 @@ dependencies = [
     'pydantic',
     'psutil',
     'aind-data-schema',
+    'aind-codeocean-api'
 ]
 
 [project.optional-dependencies]
 dev = [
+    'aind-exaspim-pipeline-utils[n5tozarr]',
     'black',
     'coverage',
     'flake8',
@@ -41,7 +43,6 @@ n5tozarr = [
     'zarr',
     'numcodecs',
     'aind-data-transfer[full]',
-#    'xarray-multiscale'
     # missing dependencies from aind-data-transfer[full]
     # These supposed to be installed by post_install.sh
 #    'hdf5plugin',
@@ -53,10 +54,12 @@ where = ["src"]
 
 [project.scripts]
 imagej_wrapper = "aind_exaspim_pipeline_utils.imagej_wrapper:main"
+imagej_wrapper_manifest = "aind_exaspim_pipeline_utils.imagej_wrapper:imagej_wrapper_main"
 n5tozarr_da_converter = "aind_exaspim_pipeline_utils.n5tozarr.n5tozarr_da:n5tozarr_da_converter"
 zarr_multiscale_converter = "aind_exaspim_pipeline_utils.n5tozarr.n5tozarr_da:zarr_multiscale_converter"
 create_example_manifest = "aind_exaspim_pipeline_utils.exaspim_manifest:create_example_manifest"
 bigstitcher_log_edge_analysis = "aind_exaspim_pipeline_utils.qc.bigstitcher_log_edge_analysis:main"
+run_trigger_capsule = "aind_exaspim_pipeline_utils.trigger.capsule:capsule_main"
 
 [tool.setuptools.dynamic]
 version = {attr = "aind_exaspim_pipeline_utils.__version__"}

--- a/src/aind_exaspim_pipeline_utils/exaspim_manifest.py
+++ b/src/aind_exaspim_pipeline_utils/exaspim_manifest.py
@@ -306,7 +306,8 @@ def get_capsule_metadata() -> dict:  # pragma: no cover
     return json_data
 
 
-def append_process_entries_to_metadata(dataset_metadata: Metadata, processes: Iterable[DataProcess]) -> None:
+def append_process_entries_to_metadata(dataset_metadata: Metadata, processes: Iterable[DataProcess]) \
+        -> None:   # pragma: no cover
     """Append the given process metadata entries to the dataset_metadata
 
     So long the pipeline is a linear sequence of steps, this should always be the
@@ -317,14 +318,14 @@ def append_process_entries_to_metadata(dataset_metadata: Metadata, processes: It
         dataset_metadata.processing.data_processes.append(process)
 
 
-def write_result_dataset_metadata(dataset_metadata: dict) -> None:
+def write_result_dataset_metadata(dataset_metadata: dict) -> None:  # pragma: no cover
     """Write the updated metadata file to the Code Ocean results folder."""
     os.makedirs("../results/meta", exist_ok=True)
     with open("../results/meta/metadata.json", "w") as f:
         json.dump(dataset_metadata, f, indent=3)
 
 
-def write_process_metadata(capsule_metadata: DataProcess, prefix=None) -> None:
+def write_process_metadata(capsule_metadata: DataProcess, prefix=None) -> None:  # pragma: no cover
     """Write the process.json file about this processing step to the Code Ocean results folder."""
     os.makedirs("../results/meta", exist_ok=True)
     if prefix is None:
@@ -335,5 +336,5 @@ def write_process_metadata(capsule_metadata: DataProcess, prefix=None) -> None:
         f.write(capsule_metadata.json(indent=3))
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     create_example_manifest(printit=True)

--- a/src/aind_exaspim_pipeline_utils/exaspim_manifest.py
+++ b/src/aind_exaspim_pipeline_utils/exaspim_manifest.py
@@ -3,13 +3,11 @@ from __future__ import annotations
 
 import json
 import os
-import sys
 from datetime import datetime
 from typing import Optional, Tuple, Iterable, List
 
-from aind_data_schema import DataProcess, Processing, Metadata
+from aind_data_schema import DataProcess, Metadata
 from aind_data_schema.base import AindModel
-from aind_data_schema.data_description import Institution
 from pydantic import Field, validator
 import argparse
 
@@ -61,6 +59,7 @@ class ZarrMultiscaleParameters(AindModel):  # pragma: no cover
 
 
 class IJWrapperParameters(AindModel):  # pragma: no cover
+    """ImageJ wrapper memory and parallelization runtime parameters"""
     memgb: int = Field(
         ...,
         title="Allowed JVM heap memory in GB."
@@ -96,6 +95,7 @@ class IPDetectionParameters(AindModel):  # pragma: no cover
 
     @validator("bead_choice")
     def validate_bead_choice(cls, v: str) -> str:
+        """Validate bead choice."""
         if v in ImagejMacros.MAP_BEAD_CHOICE.keys():
             return v
         else:
@@ -105,6 +105,7 @@ class IPDetectionParameters(AindModel):  # pragma: no cover
 
     @validator("ip_limitation_choice")
     def validate_ip_limitation_choice(cls, v: str) -> str:
+        """Validate ip limitation choice."""
         if v in ImagejMacros.MAP_IP_LIMITATION_CHOICE.keys():
             return v
         else:
@@ -137,6 +138,7 @@ class IPRegistrationParameters(AindModel):  # pragma: no cover
 
     @validator("transformation_choice")
     def validate_transformation_choice(cls, v: str) -> str:
+        """Validate transformation choice"""
         if v in ImagejMacros.MAP_TRANSFORMATION.keys():
             return v
         else:
@@ -146,6 +148,7 @@ class IPRegistrationParameters(AindModel):  # pragma: no cover
 
     @validator("compare_views_choice")
     def validate_compare_views_choice(cls, v: str) -> str:
+        """Validate compare views choice."""
         if v in ImagejMacros.MAP_COMPARE_VIEWS.keys():
             return v
         else:
@@ -155,6 +158,7 @@ class IPRegistrationParameters(AindModel):  # pragma: no cover
 
     @validator("interest_point_inclusion_choice")
     def validate_interest_point_inclusion_choice(cls, v: str) -> str:
+        """Validate interest point inclusion choice"""
         if v in ImagejMacros.MAP_INTEREST_POINT_INCLUSION.keys():
             return v
         else:
@@ -166,6 +170,7 @@ class IPRegistrationParameters(AindModel):  # pragma: no cover
 
     @validator("fix_views_choice")
     def validate_fix_views_choice(cls, v: str) -> str:
+        """Validate fix views choice"""
         if v in ImagejMacros.MAP_FIX_VIEWS.keys():
             return v
         else:
@@ -175,6 +180,7 @@ class IPRegistrationParameters(AindModel):  # pragma: no cover
 
     @validator("map_back_views_choice")
     def validate_map_back_views_choice(cls, v: str) -> str:
+        """Validate map back views choice"""
         if v in ImagejMacros.MAP_MAP_BACK_VIEWS.keys():
             return v
         else:
@@ -184,6 +190,7 @@ class IPRegistrationParameters(AindModel):  # pragma: no cover
 
     @validator("regularize_with_choice")
     def validate_regularize_with_choice(cls, v: str) -> str:
+        """Validate regularize with choice"""
         if v in ImagejMacros.MAP_REGULARIZATION.keys():
             return v
         else:
@@ -225,7 +232,8 @@ class ExaspimProcessingPipeline(AindModel):  # pragma: no cover
     pipeline_suffix: str = Field(..., title="Filename timestamp suffix")
     name: Optional[str] = Field(
         None,
-        description="Name of data, conventionally also the name of the directory containing all data and metadata",
+        description="Name of data, conventionally also the name of "
+                    "the directory containing all data and metadata",
         title="Name",
     )
 
@@ -269,7 +277,8 @@ def create_example_manifest(printit=True) -> ExaspimProcessingPipeline | None:  
     return processing_manifest_example
 
 
-def get_capsule_manifest(args: Optional[argparse.Namespace] = None) -> ExaspimProcessingPipeline:  # pragma: no cover
+def get_capsule_manifest(args: Optional[argparse.Namespace] = None) \
+        -> ExaspimProcessingPipeline:  # pragma: no cover
     """Get the manifest file from its Code Ocean location or as given in the cmd-line argument.
 
     Raises
@@ -301,7 +310,8 @@ def append_process_entries_to_metadata(dataset_metadata: Metadata, processes: It
     """Append the given process metadata entries to the dataset_metadata
 
     So long the pipeline is a linear sequence of steps, this should always be the
-    case. Otherwise the process metadata should be collected and appended at the end of the parallel processing capsules.
+    case. Otherwise the process metadata should be collected and appended
+    at the end of the parallel processing capsules.
     """
     for process in processes:
         dataset_metadata.processing.data_processes.append(process)

--- a/src/aind_exaspim_pipeline_utils/exaspim_manifest.py
+++ b/src/aind_exaspim_pipeline_utils/exaspim_manifest.py
@@ -1,37 +1,22 @@
 """Manifest declaration for the exaSPIM capsules"""
+from __future__ import annotations
+
+import json
 import os
 import sys
 from datetime import datetime
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Iterable, List
 
-from aind_data_schema import DataProcess, Processing
+from aind_data_schema import DataProcess, Processing, Metadata
 from aind_data_schema.base import AindModel
 from aind_data_schema.data_description import Institution
-from aind_data_transfer.util import file_utils
-from pydantic import Field
+from pydantic import Field, validator
+import argparse
+
+from .imagej_macros import ImagejMacros
 
 
 # Based on aind-data-transfer/scripts/processing_manifest.py
-
-
-class DatasetStatus(AindModel):  # pragma: no cover
-    """Status of the datasets to control next processing step. TBD"""
-
-    # status: Status = Field(
-    #     ...,
-    #     description="Status of the dataset on the local storage",
-    #     title="Institution",
-    #     enumNames=[i.value for i in Status],
-    # )
-    # Creating datetime
-    status_date = Field(
-        datetime.now().date().strftime("%Y-%m-%d"),
-        title="Date the flag was created",
-    )
-    status_time = Field(
-        datetime.now().time().strftime("%H-%M-%S"),
-        title="Time the flag was created",
-    )
 
 
 class N5toZarrParameters(AindModel):  # pragma: no cover
@@ -46,14 +31,14 @@ class N5toZarrParameters(AindModel):  # pragma: no cover
     input_uri: str = Field(
         ...,
         title="Input N5 dataset path. Must be a local filesystem path or "
-        "start with s3:// to trigger S3 direct access.",
+              "start with s3:// to trigger S3 direct access.",
     )
 
     output_uri: str = Field(
         ...,
         title="Output Zarr dataset path. Must be a local filesystem path or "
-        "start with s3:// to trigger S3 direct access. "
-        "Must be different from the input_uri. Will be overwritten if exists.",
+              "start with s3:// to trigger S3 direct access. "
+              "Must be different from the input_uri. Will be overwritten if exists.",
     )
 
 
@@ -69,10 +54,160 @@ class ZarrMultiscaleParameters(AindModel):  # pragma: no cover
     input_uri: str = Field(
         ...,
         title="Input Zarr group dataset path. Must be a local filesystem path or "
-        "start with s3:// to trigger S3 direct access.",
+              "start with s3:// to trigger S3 direct access.",
     )
 
     output_uri: Optional[str] = Field(None, title="Output Zarr group dataset path if different from input.")
+
+
+class IJWrapperParameters(AindModel):  # pragma: no cover
+    memgb: int = Field(
+        ...,
+        title="Allowed JVM heap memory in GB."
+              " Should be about 0.8 GB x number of parallel threads less than total available.",
+        ge=16,
+    )
+    parallel: int = Field(..., title="Number of parallel Java worker threads.", ge=1, lt=128)
+
+
+class IPDetectionParameters(AindModel):  # pragma: no cover
+    """Interest point detection parameters"""
+
+    # dataset_xml: str = Field(..., title="NOT USED. BigStitcher xml dataset file in s3.")
+    IJwrap: IJWrapperParameters = Field(..., title="ImageJ wrapper settings")
+
+    downsample: int = Field(4, title="Downsampling factor. Use the one that is available in the dataset.")
+    bead_choice: str = Field("manual", title="Beads detection mode")
+    sigma: float = Field(1.8, title="Difference of Gaussians sigma (beads_mode==manual only)")
+    threshold: float = Field(
+        0.1, title="Difference of Gaussians detection threshold " "(beads_mode==manual only)."
+    )
+    find_minima: bool = Field(False, title="Find minima (beads_mode==manual only).")
+    find_maxima: bool = Field(True, title="Find maxima (beads_mode==manual only).")
+    set_minimum_maximum: bool = Field(False, title="Define the minimum and maximum intensity range manually")
+    minimal_intensity: int = Field(0, title="Minimal intensity value (if set_minimum_maximum==True).")
+    maximal_intensity: int = Field(65535, title="Minimal intensity value (if set_minimum_maximum==True).")
+    maximum_number_of_detections: int = Field(
+        0, title="If not equal to 0, the number of maximum IPs to detect. Set ip_limitation_choice, too."
+    )
+    ip_limitation_choice: str = Field(
+        ..., title="How to pick limit_amount_of_detections is set >0 and the maximum number is hit."
+    )
+
+    @validator("bead_choice")
+    def validate_bead_choice(cls, v: str) -> str:
+        if v in ImagejMacros.MAP_BEAD_CHOICE.keys():
+            return v
+        else:
+            raise ValueError(
+                "bead_choice must be one of {}".format(list(ImagejMacros.MAP_BEAD_CHOICE.keys()))
+            )
+
+    @validator("ip_limitation_choice")
+    def validate_ip_limitation_choice(cls, v: str) -> str:
+        if v in ImagejMacros.MAP_IP_LIMITATION_CHOICE.keys():
+            return v
+        else:
+            raise ValueError(
+                "ip_limitation_choice must be one of {}".format(
+                    list(ImagejMacros.MAP_IP_LIMITATION_CHOICE.keys())
+                )
+            )
+
+
+class IPRegistrationParameters(AindModel):  # pragma: no cover
+    """Interest point based registration parameters"""
+
+    # dataset_xml: str = Field(..., title="BigStitcher xml dataset file.")
+    IJwrap: IJWrapperParameters = Field(..., title="ImageJ wrapper settings")
+    transformation_choice: str = Field(..., title="Translation, rigid or full affine transformation ?")
+    compare_views_choice: str = Field(..., title="Which views to compare ?")
+    interest_point_inclusion_choice: str = Field(..., title="Which interest points to use ?")
+    fix_views_choice: str = Field(..., title="Which views to fix ?")
+    fixed_tile_ids: List[int] = Field(
+        [0, ], title="Setup ids of fixed tiles (fix_views_choice==select_fixed)."
+    )
+    map_back_views_choice: str = Field(..., title="How to map back views?")
+    map_back_reference_view: int = Field(0, title="Selected reference view for map back.")
+    do_regularize: bool = Field(False, title="Do regularize transformation?")
+    regularization_lambda: float = Field(0.1, title="Regularization lambda (do_regularize==True only).")
+    regularize_with_choice: str = Field(
+        "rigid", title="Which regularization to use (do_regularize==True only) ?"
+    )
+
+    @validator("transformation_choice")
+    def validate_transformation_choice(cls, v: str) -> str:
+        if v in ImagejMacros.MAP_TRANSFORMATION.keys():
+            return v
+        else:
+            raise ValueError(
+                "transformation_choice must be one of {}".format(list(ImagejMacros.MAP_TRANSFORMATION.keys()))
+            )
+
+    @validator("compare_views_choice")
+    def validate_compare_views_choice(cls, v: str) -> str:
+        if v in ImagejMacros.MAP_COMPARE_VIEWS.keys():
+            return v
+        else:
+            raise ValueError(
+                "compare_views_choice must be one of {}".format(list(ImagejMacros.MAP_COMPARE_VIEWS.keys()))
+            )
+
+    @validator("interest_point_inclusion_choice")
+    def validate_interest_point_inclusion_choice(cls, v: str) -> str:
+        if v in ImagejMacros.MAP_INTEREST_POINT_INCLUSION.keys():
+            return v
+        else:
+            raise ValueError(
+                "interest_point_inclusion_choice must be one of {}".format(
+                    list(ImagejMacros.MAP_INTEREST_POINT_INCLUSION.keys())
+                )
+            )
+
+    @validator("fix_views_choice")
+    def validate_fix_views_choice(cls, v: str) -> str:
+        if v in ImagejMacros.MAP_FIX_VIEWS.keys():
+            return v
+        else:
+            raise ValueError(
+                "fix_views_choice must be one of {}".format(list(ImagejMacros.MAP_FIX_VIEWS.keys()))
+            )
+
+    @validator("map_back_views_choice")
+    def validate_map_back_views_choice(cls, v: str) -> str:
+        if v in ImagejMacros.MAP_MAP_BACK_VIEWS.keys():
+            return v
+        else:
+            raise ValueError(
+                "map_back_views_choice must be one of {}".format(list(ImagejMacros.MAP_MAP_BACK_VIEWS.keys()))
+            )
+
+    @validator("regularize_with_choice")
+    def validate_regularize_with_choice(cls, v: str) -> str:
+        if v in ImagejMacros.MAP_REGULARIZATION.keys():
+            return v
+        else:
+            raise ValueError(
+                "regularize_with_choice must be one of {}".format(
+                    list(ImagejMacros.MAP_REGULARIZATION.keys())
+                )
+            )
+
+
+class XMLCreationParameters(AindModel):  # pragma: no cover
+    """XML converter capsule parameters."""
+
+    input_uri: str = Field(
+        ...,
+        title="Top level s3 uri for input dataset.",
+    )
+
+    output_uri: str = Field(
+        ...,
+        title="Output Zarr dataset path. Must be a local filesystem path or "
+              "start with s3:// to trigger S3 direct access. "
+              "Must be different from the input_uri. Will be overwritten if exists.",
+    )
 
 
 class ExaspimProcessingPipeline(AindModel):  # pragma: no cover
@@ -80,48 +215,29 @@ class ExaspimProcessingPipeline(AindModel):  # pragma: no cover
 
     If a field is None, it is considered to be a disabled step."""
 
+    schema_version: str = Field("0.11.0", title="Schema Version", const=True)
+    license: str = Field("CC-BY-4.0", title="License", const=True)
+
+    creation_time: datetime = Field(
+        ...,
+        title="UTC Creation time of manifest",
+    )
+    pipeline_suffix: str = Field(..., title="Filename timestamp suffix")
+    name: Optional[str] = Field(
+        None,
+        description="Name of data, conventionally also the name of the directory containing all data and metadata",
+        title="Name",
+    )
+
+    ip_detection: IPDetectionParameters = Field(None, title="Interest point detection")
+    ip_registrations: List[IPRegistrationParameters] = Field(
+        None, title="List of interest point registration steps."
+    )
     n5_to_zarr: N5toZarrParameters = Field(None, title="N5 to single scale Zarr conversion")
     zarr_multiscale: ZarrMultiscaleParameters = Field(None, title="Zarr to multiscale Zarr conversion")
 
 
-class ExaspimManifest(AindModel):  # pragma: no cover
-    """Manifest definition of an exaSPIM processing session.
-
-    Connects the dataset and its pipeline processing history."""
-
-    schema_version: str = Field("0.1.0", title="Schema Version", const=True)
-    license: str = Field("CC-BY-4.0", title="License", const=True)
-
-    specimen_id: str = Field(..., title="Specimen ID")
-    # dataset_status: DatasetStatus = Field(
-    #     ..., title="Dataset status", description="Dataset status"
-    # )
-    institution: Institution = Field(
-        ...,
-        description="An established society, corporation, foundation or other organization "
-        "that collected this data",
-        title="Institution",
-        enumNames=[i.value.name for i in Institution],
-    )
-    # acquisition: Acquisition = Field(
-    #     ...,
-    #     title="Acquisition data",
-    #     description="Acquition data coming from the rig which is necessary to create matadata files",
-    # )
-
-    processing_pipeline: ExaspimProcessingPipeline = Field(
-        ...,
-        title="ExaSPIM pipeline parameters",
-        description="Parameters necessary for the exaspim pipeline steps.",
-    )
-    processing: Processing = Field(
-        ...,
-        title="ExaSPIM pipeline processing steps log",
-        description="Processing steps that has already taken place.",
-    )
-
-
-def create_example_manifest(printit=True) -> ExaspimManifest:  # pragma: no cover
+def create_example_manifest(printit=True) -> ExaspimProcessingPipeline | None:  # pragma: no cover
     """Create example manifest file
 
     Parameters
@@ -133,24 +249,18 @@ def create_example_manifest(printit=True) -> ExaspimManifest:  # pragma: no cove
     -------
     example_manifest: ExaspimManifest
     """
-    # print(ProcessingManifest.schema_json(indent=2))
-    # print(ProcessingManifest.schema())
-
-    processing_manifest_example = ExaspimManifest(
-        specimen_id="653431",
-        institution=Institution.AIND,
-        processing_pipeline=ExaspimProcessingPipeline(
-            n5_to_zarr=N5toZarrParameters(
-                voxel_size_zyx=(1.0, 0.748, 0.748),
-                input_uri="s3://aind-scratch-data/gabor.kovacs/2023-07-25_1653_BSS_fusion_653431/ch561/",
-                output_uri="s3://aind-scratch-data/gabor.kovacs/n5_to_zarr_CO_2023-08-17_1351/",
-            ),
-            zarr_multiscale=ZarrMultiscaleParameters(
-                voxel_size_zyx=(1.0, 0.748, 0.748),
-                input_uri="s3://aind-scratch-data/gabor.kovacs/2023-07-25_1653_BSS_fusion_653431/ch561/",
-            ),
+    processing_manifest_example = ExaspimProcessingPipeline(
+        pipeline_suffix="2023-12-07_00-00-00",
+        creation_time=datetime.utcnow(),
+        n5_to_zarr=N5toZarrParameters(
+            voxel_size_zyx=(1.0, 0.748, 0.748),
+            input_uri="s3://aind-scratch-data/gabor.kovacs/2023-07-25_1653_BSS_fusion_653431/ch561/",
+            output_uri="s3://aind-scratch-data/gabor.kovacs/n5_to_zarr_CO_2023-08-17_1351/",
         ),
-        processing=Processing(data_processes=[]),
+        zarr_multiscale=ZarrMultiscaleParameters(
+            voxel_size_zyx=(1.0, 0.748, 0.748),
+            input_uri="s3://aind-scratch-data/gabor.kovacs/2023-07-25_1653_BSS_fusion_653431/ch561/",
+        ),
     )
 
     if printit:
@@ -159,41 +269,59 @@ def create_example_manifest(printit=True) -> ExaspimManifest:  # pragma: no cove
     return processing_manifest_example
 
 
-def get_capsule_manifest():  # pragma: no cover
+def get_capsule_manifest(args: Optional[argparse.Namespace] = None) -> ExaspimProcessingPipeline:  # pragma: no cover
     """Get the manifest file from its Code Ocean location or as given in the cmd-line argument.
 
     Raises
     ------
     If the manifest is not found, required fields will be missing at schema validation.
     """
-    if len(sys.argv) > 1:
-        manifest_name = sys.argv[1]
+    if args is not None:
+        manifest_name = args.manifest_name
     else:
-        manifest_name = "data/manifest/exaspim_manifest.json"
-    json_data = file_utils.read_json_as_dict(manifest_name)
-    return ExaspimManifest(**json_data)
+        manifest_name = "../data/manifest/exaspim_manifest.json"
+    with open(manifest_name, "r") as f:
+        json_data = json.load(f)
+    return ExaspimProcessingPipeline(**json_data)
 
 
-def append_metadata_to_manifest(capsule_manifest: ExaspimManifest, process: DataProcess) -> None:
-    """Append the given dataprocess metadata to the exaspim pipeline manifest
+def get_capsule_metadata() -> dict:  # pragma: no cover
+    """Get the metadata file from its Code Ocean location"""
+    metadata_name = "../data/meta/metadata.json"
+    if os.path.exists(metadata_name):
+        with open(metadata_name) as json_file:
+            json_data = json.load(json_file)
+    else:
+        json_data = {}
+    # return Metadata.parse_obj(json_data)
+    return json_data
+
+
+def append_process_entries_to_metadata(dataset_metadata: Metadata, processes: Iterable[DataProcess]) -> None:
+    """Append the given process metadata entries to the dataset_metadata
 
     So long the pipeline is a linear sequence of steps, this should always be the
-    case.
+    case. Otherwise the process metadata should be collected and appended at the end of the parallel processing capsules.
     """
-    capsule_manifest.processing.data_processes.append(process)
+    for process in processes:
+        dataset_metadata.processing.data_processes.append(process)
 
 
-def write_result_manifest(capsule_manifest: ExaspimManifest) -> None:
-    """Write the updated manifest file to the Code Ocean results folder."""
-    os.makedirs("results/manifest", exist_ok=True)
-    with open("results/manifest/exaspim_manifest.json", "w") as f:
-        f.write(capsule_manifest.json(indent=3))
+def write_result_dataset_metadata(dataset_metadata: dict) -> None:
+    """Write the updated metadata file to the Code Ocean results folder."""
+    os.makedirs("../results/meta", exist_ok=True)
+    with open("../results/meta/metadata.json", "w") as f:
+        json.dump(dataset_metadata, f, indent=3)
 
 
-def write_result_metadata(capsule_metadata: DataProcess) -> None:
-    """Write the metadata file to the Code Ocean results folder."""
-    os.makedirs("results/meta", exist_ok=True)
-    with open("results/meta/exaspim_process.json", "w") as f:
+def write_process_metadata(capsule_metadata: DataProcess, prefix=None) -> None:
+    """Write the process.json file about this processing step to the Code Ocean results folder."""
+    os.makedirs("../results/meta", exist_ok=True)
+    if prefix is None:
+        prefix = ""
+    else:
+        prefix = prefix + "_"
+    with open(f"../results/meta/exaspim_{prefix}process.json", "w") as f:
         f.write(capsule_metadata.json(indent=3))
 
 

--- a/src/aind_exaspim_pipeline_utils/imagej_wrapper.py
+++ b/src/aind_exaspim_pipeline_utils/imagej_wrapper.py
@@ -18,7 +18,7 @@ from aind_data_schema.processing import ProcessName
 
 from . import __version__
 from .imagej_macros import ImagejMacros
-from .exaspim_manifest import ExaspimProcessingPipeline, get_capsule_manifest, write_process_metadata
+from .exaspim_manifest import get_capsule_manifest, write_process_metadata
 
 
 class IPDetectionSchema(argschema.ArgSchema):  # pragma: no cover

--- a/src/aind_exaspim_pipeline_utils/qc/bigstitcher_log_edge_analysis.py
+++ b/src/aind_exaspim_pipeline_utils/qc/bigstitcher_log_edge_analysis.py
@@ -2,11 +2,10 @@
 import re
 import sys
 from typing import Iterable, List, Tuple
-
 import numpy as np
 
 
-def get_unfitted_tile_pairs(lines: Iterable[str]) -> List[List[Tuple[int, int]]]:
+def get_unfitted_tile_pairs(lines: Iterable[str]) -> List[List[Tuple[int, int]]]:  # pragma: no cover
     """Extract tile pair numbers from log lines of failed RANSAC correspondence
     finding.
 
@@ -60,7 +59,7 @@ def get_unfitted_tile_pairs(lines: Iterable[str]) -> List[List[Tuple[int, int]]]
     return blocks
 
 
-def create_ascii_visualization(pairs: Iterable[Tuple[int, int]]) -> str:
+def create_ascii_visualization(pairs: Iterable[Tuple[int, int]]) -> str:  # pragma: no cover
     """Assuming the 3x5 tile configuration of exaSPIM, show which edges have failed.
 
     Tile grid is 3x5 with tile 0 is top right, tile 14 is bottom left. Tiles are marked
@@ -89,7 +88,7 @@ def create_ascii_visualization(pairs: Iterable[Tuple[int, int]]) -> str:
     return "\n".join(" ".join(x[::-1]) for x in A)
 
 
-def print_visualization(blocks, file=None):
+def print_visualization(blocks, file=None):  # pragma: no cover
     """Print ascii visualization of edges for multiple blocks."""
 
     for i, pairs in enumerate(blocks):
@@ -99,12 +98,12 @@ def print_visualization(blocks, file=None):
         print(file=file)
 
 
-def main():
+def main():  # pragma: no cover
     """Standalone script entry point."""
     # By default, process stdin
     blocks = get_unfitted_tile_pairs(sys.stdin)
     print_visualization(blocks)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()

--- a/src/aind_exaspim_pipeline_utils/qc/bigstitcher_log_edge_analysis.py
+++ b/src/aind_exaspim_pipeline_utils/qc/bigstitcher_log_edge_analysis.py
@@ -98,11 +98,13 @@ def print_visualization(blocks, file=None):
         print(create_ascii_visualization(pairs), file=file)
         print(file=file)
 
+
 def main():
     """Standalone script entry point."""
     # By default, process stdin
     blocks = get_unfitted_tile_pairs(sys.stdin)
     print_visualization(blocks)
+
 
 if __name__ == "__main__":
     main()

--- a/src/aind_exaspim_pipeline_utils/trigger/__init__.py
+++ b/src/aind_exaspim_pipeline_utils/trigger/__init__.py
@@ -1,0 +1,1 @@
+"""Trigger capsule init"""

--- a/src/aind_exaspim_pipeline_utils/trigger/capsule.py
+++ b/src/aind_exaspim_pipeline_utils/trigger/capsule.py
@@ -1,0 +1,469 @@
+"""Trigger capsule actions"""
+
+import argparse
+import datetime
+import os
+import time
+from typing import Optional
+
+import boto3
+import json
+from urllib.parse import urlparse
+import urllib.request
+
+import botocore.client
+from aind_codeocean_api.codeocean import CodeOceanClient
+from aind_codeocean_api.credentials import CodeOceanCredentials
+from aind_data_schema import DataProcess, DataDescription
+from aind_data_schema.data_description import Institution
+
+from ..exaspim_manifest import (
+    IJWrapperParameters,
+    IPDetectionParameters,
+    IPRegistrationParameters,
+    ExaspimProcessingPipeline,
+    N5toZarrParameters,
+    ZarrMultiscaleParameters,
+)
+
+
+def get_fname_timestamp(stamp: Optional[datetime.datetime] = None) -> str:
+    """Get the time in the format used in the file names YYYY-MM-DD_HH-MM-SS"""
+    if stamp is None:
+        stamp = datetime.datetime.utcnow()
+    return stamp.strftime("%Y-%m-%d_%H-%M-%S")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="run_trigger_capsule",
+        description="This program prepares the CO environment and launches the exaSPIM processing pipeline",
+    )
+    parser.add_argument("--pipeline_id", help="CO pipeline id to launch")
+    parser.add_argument(
+        "exaspim_data_uri", help="S3 URI Top-level location of exaSPIM " "dataset in aind-open-data"
+    )
+    parser.add_argument("manifest_prefix_uri", help="S3 prefix URI for processing manifest upload")
+    parser.add_argument("--pipeline_timestamp", help="Pipeline timestamp to be appended to folder names. "
+                                                     "Defaults to current UTC time as YYYY-MM-DD_HH-MM-SS")
+    parser.add_argument("--xml_capsule_id", help="XML converter capsule id. Runs it if present.")
+    parser.add_argument("--ij_capsule_id", help="ImageJ wrapper capsule id. Starts it if present.")
+    args = parser.parse_args()
+    return args
+
+
+# TODO: Use validated model, once stable
+def get_dataset_metadata(args) -> dict:
+    """Get the metadata of the exaspim dataset from S3.
+
+    Also gets the acquisition.json if available and puts into the dict.
+    """
+
+    s3 = boto3.client("s3")  # Authentication should be available in the environment
+
+    object_name = "/".join((args.dataset_prefix, "metadata.json"))
+
+    # Download the file from S3
+    print(f"Downloading from bucket {args.dataset_bucket_name} : {object_name}")
+    s3.download_file(args.dataset_bucket_name, object_name, "../results/metadata.json")
+
+    # Parse the JSON file
+    with open("../results/metadata.json", "r") as f:
+        metadata = json.load(f)
+
+    object_name = "/".join((args.dataset_prefix, "acquisition.json"))
+    # Download the file from S3
+    print(f"Downloading from bucket {args.dataset_bucket_name} : {object_name}")
+    s3.download_file(args.dataset_bucket_name, object_name, "../results/acquisition.json")
+
+    if os.path.exists("../results/acquisition.json"):
+        with open("../results/acquisition.json", "r") as f:
+            acqdata = json.load(f)
+        if acqdata:
+            metadata['acquisition'] = acqdata
+
+    return metadata
+
+
+def validate_s3_location(args, meta):
+    """Get the last data_process and check whether we're at its output location"""
+    lastproc: DataProcess = DataProcess.parse_obj(meta["processing"]["data_processes"][-1])
+    meta_url = urlparse(lastproc.output_location)
+
+    if meta_url.netloc != args.dataset_bucket_name or meta_url.path.strip("/") != args.dataset_prefix:
+        raise ValueError("Output location of last DataProcess does not match with current dataset location")
+
+
+def wait_for_data_availability(
+        co_client,
+        data_asset_id: str,
+        timeout_seconds: int = 300,
+        pause_interval=10,
+):
+    """
+    There is a lag between when a register data request is made and when the
+    data is available to be used in a capsule.
+    Parameters
+    ----------
+    data_asset_id : str
+    timeout_seconds : int
+        Roughly how long the method should check if the data is available.
+    pause_interval : int
+        How many seconds between when the backend is queried.
+
+    Returns
+    -------
+    requests.Response
+
+    """
+    num_of_checks = 0
+    break_flag = False
+    time.sleep(pause_interval)
+    response = co_client.get_data_asset(data_asset_id)
+
+    if ((pause_interval * num_of_checks) > timeout_seconds) or (response.status_code == 200):
+        break_flag = True
+    while not break_flag:
+        print("Data asset is not yet available")
+        print(response)
+        time.sleep(pause_interval)
+        response = co_client.get_data_asset(data_asset_id)
+        num_of_checks += 1
+        if ((pause_interval * num_of_checks) > timeout_seconds) or (response.status_code == 200):
+            break_flag = True
+    return response
+
+def wait_for_compute_completion(
+        co_api,
+        compute_id: str,
+        timeout_seconds: int= 300,
+        pause_interval: int= 5,
+):
+    """
+    
+    Parameters
+    ----------
+    data_asset_id : str
+    timeout_seconds : int
+        Roughly how long the method should check if the data is available.
+    pause_interval : int
+        How many seconds between when the backend is queried.
+
+    Returns
+    -------
+    run_status: dict
+        last run_status as json dict.
+
+    """
+    for i_check in range(timeout_seconds // pause_interval + 2):
+        time.sleep(pause_interval)
+        run_status = co_api.get_computation(compute_id)
+        if run_status.status_code != 200:
+            raise RuntimeError(f"Cannot get compute status {compute_id}")
+        run_status = run_status.json()
+        if run_status['state']=='completed' and run_status['has_results'] and\
+            run_status['end_status']=='succeeded':
+            break
+        print(f"Waiting loop {i_check}: {run_status}")
+    else:
+        raise RuntimeError(f"Wait for {compute_id} timed out or ended unsuccessfully.")
+    return run_status
+
+def make_data_viewable(co_client: CodeOceanClient, data_asset_id: str):
+    """
+    Makes a registered dataset viewable
+
+    Parameters
+    ----------
+    co_client: CodeOceanClient
+        Code ocean client
+
+    """
+    response_data_available = wait_for_data_availability(co_client, data_asset_id)
+
+    if response_data_available.status_code != 200:
+        raise FileNotFoundError(f"Unable to find: {data_asset_id}")
+
+    # Make data asset viewable to everyone
+    update_data_perm_response = co_client.update_permissions(data_asset_id=data_asset_id, everyone="viewer")
+    print(f"Data asset viewable to everyone: {update_data_perm_response}")
+
+
+def register_raw_dataset_as_CO_data_asset(args, meta, co_api):
+    """Register the dataset as a linked S3 data asset in CO"""
+    # TODO: Current metadata fails with schema validation
+    # data_description: DataDescription = DataDescription.parse_obj(meta["data_description"])
+    tags = ["exaspim", "raw"]
+
+    # TODO: Newer version of co_api supports custom metadata entries. Fill from metadata/data_description
+    # Registering data asset
+    data_asset_reg_response = co_api.register_data_asset(
+        asset_name=args.dataset_name,
+        mount=args.dataset_name,
+        bucket=args.dataset_bucket_name,
+        prefix=args.dataset_prefix,
+        tags=tags,
+    )
+    print(data_asset_reg_response)
+    response_contents = data_asset_reg_response.json()
+    print(f"Created data asset in Code Ocean: {response_contents}")
+
+    data_asset_id = response_contents["id"]
+    # Making the created data asset available for everyone
+    make_data_viewable(co_api, data_asset_id)
+
+    return data_asset_id
+
+
+def register_manifest_as_CO_data_asset(args, co_api):
+    """Register the manifest as a linked S3 data asset in CO"""
+    # TODO: Current metadata fails with schema validation
+    # data_description: DataDescription = DataDescription.parse_obj(meta["data_description"])
+    tags = ["exaspim", "manifest"]
+
+    # TODO: Newer version of co_api supports custom metadata entries. Fill from metadata/data_description
+    # Registering data asset
+    data_asset_reg_response = co_api.register_data_asset(
+        asset_name=args.manifest_name,
+        mount="manifest",
+        bucket=args.manifest_bucket_name,
+        prefix=args.manifest_path,
+        tags=tags,
+    )
+    response_contents = data_asset_reg_response.json()
+    print(f"Created data asset in Code Ocean: {response_contents}")
+
+    data_asset_id = response_contents["id"]
+    # Making the created data asset available for everyone
+    make_data_viewable(co_api, data_asset_id)
+
+    return data_asset_id
+
+
+def start_pipeline(args, co_api, manifest_data_asset_id):
+    # mount
+    data_assets = [
+        {"id": manifest_data_asset_id, "mount": "manifest"},
+    ]
+
+    # dumped_parameters = json.dumps(job_configs)
+    # print(dumped_parameters)
+    # Executing capsule attaching new data asset
+    run_response = co_api.run_capsule(
+        capsule_id=args.pipeline_id,
+        data_assets=data_assets,
+        parameters=None,
+    )
+
+    print(f"Run response: {run_response.json()}")
+    time.sleep(5)
+
+def run_xml_capsule(args, co_api, raw_data_asset_id):
+    """Run the xml generator capsule.
+
+      * Attach the raw_data_asset_id as exaspim_dataset to the capsule
+      * Run the capsule and waits for completion.
+      * Download output.xml and upload it to the manifest location.
+    """
+    data_assets = [
+        {"id": raw_data_asset_id, "mount": "exaspim_dataset"},
+    ]
+
+    # dumped_parameters = json.dumps(job_configs)
+    # print(dumped_parameters)
+    # Executing capsule attaching new data asset
+    run_response = co_api.run_capsule(
+        capsule_id=args.xml_capsule_id,
+        data_assets=data_assets,
+        parameters=None,
+    )
+
+    run_response = run_response.json()
+    compute_id = run_response["id"]
+
+    print(f"Run response: {run_response}")
+    wait_for_compute_completion(co_api, compute_id)
+
+    result_response = co_api.get_result_file_download_url(run_response["id"],"output.xml")
+    result = result_response.json()
+    if result_response.status_code != 200 or 'url' not in result:
+        raise RuntimeError("Cannot get xml capsule result")
+    print(f"Result query response: {result}")
+    urllib.request.urlretrieve(result['url'], "../results/dataset.xml")
+    # Upload
+    s3 = boto3.client("s3")  # Authentication should be available in the environment
+    object_name = "/".join((args.manifest_path, "dataset.xml"))
+    print(f"Uploading to bucket {args.manifest_bucket_name} : {object_name}")
+    s3.upload_file("../results/dataset.xml", args.manifest_bucket_name, object_name)
+
+def start_ij_capsule(args, co_api, raw_data_asset_id, manifest_data_asset_id):
+    """Start the IJ wrapper capsule.
+    """
+    data_assets = [
+        {"id": raw_data_asset_id, "mount": "exaspim_dataset"},
+        {"id": manifest_data_asset_id, "mount": "manifest"}
+    ]
+
+    print("Starting IJ wrapper capsule")
+    run_response = co_api.run_capsule(
+        capsule_id=args.ij_capsule_id,
+        data_assets=data_assets,
+        parameters=None,
+    )
+
+    run_response = run_response.json()
+    print(f"Run response: {run_response}")
+
+def get_channel_name(metadata: dict):
+    if 'acquisition' in metadata:
+        acq = metadata['acquisition']
+        ch_name = acq["tiles"][0]["channel"]["channel_name"]
+    else:
+        print("Warning: Cannot get channel name, defaults to ch488")
+        ch_name = "ch488"
+    return ch_name
+
+def create_exaspim_manifest(args, metadata):
+    """Create exaspim manifest from the metadata that we have"""
+    # capsule_xml_path = "../data/manifest/dataset.xml"
+    def_ij_wrapper_parameters: IJWrapperParameters = IJWrapperParameters(memgb=106, parallel=32)
+    def_ip_detection_parameters: IPDetectionParameters = IPDetectionParameters(
+        # dataset_xml=capsule_xml_path,  # For future S3 path
+        IJwrap=def_ij_wrapper_parameters,
+        downsample=4,
+        bead_choice="manual",
+        sigma=1.8,
+        threshold=0.03,
+        find_minima=False,
+        find_maxima=True,
+        set_minimum_maximum=True,
+        minimal_intensity=0,
+        maximal_intensity=2000,
+        ip_limitation_choice="brightest",
+        maximum_number_of_detections=150000,
+    )
+    ip_reg_translation: IPRegistrationParameters = IPRegistrationParameters(
+        # dataset_xml=capsule_xml_path,
+        IJwrap=def_ij_wrapper_parameters,
+        transformation_choice="translation",
+        compare_views_choice="overlapping_views",
+        interest_point_inclusion_choice="overlapping_ips",
+        fix_views_choice="select_fixed",
+        fixed_tile_ids=(7,),
+        map_back_views_choice="no_mapback",
+        do_regularize=False,
+    )
+    ip_reg_affine: IPRegistrationParameters = IPRegistrationParameters(
+        # dataset_xml=capsule_xml_path,
+        IJwrap=def_ij_wrapper_parameters,
+        transformation_choice="affine",
+        compare_views_choice="overlapping_views",
+        interest_point_inclusion_choice="overlapping_ips",
+        fix_views_choice="select_fixed",
+        fixed_tile_ids=(7,),
+        map_back_views_choice="no_mapback",
+        do_regularize=True,
+        regularize_with_choice="rigid",
+    )
+
+    ch_name = get_channel_name(metadata)
+    # TODO: Generate plausible URIs
+    n5_to_zarr: N5toZarrParameters = N5toZarrParameters(
+        voxel_size_zyx=(1.0, 0.748, 0.748),
+        input_uri=f"s3://{args.dataset_bucket_name}/{args.dataset_prefix}"
+            f"_fusion_{args.fname_timestamp}/fused.n5/{ch_name}/",
+        output_uri=f"s3://{args.dataset_bucket_name}/{args.dataset_prefix}"
+            f"_fusion_{args.fname_timestamp}/fused.zarr/",
+    )
+
+    zarr_multiscale: ZarrMultiscaleParameters = ZarrMultiscaleParameters(
+        voxel_size_zyx=(1.0, 0.748, 0.748),
+        input_uri=f"s3://{args.dataset_bucket_name}/{args.dataset_prefix}"
+            f"_fusion_{args.fname_timestamp}/fused.zarr/",
+    )
+
+    processing_manifest: ExaspimProcessingPipeline = ExaspimProcessingPipeline(
+        creation_time=args.pipeline_timestamp,
+        pipeline_suffix=args.fname_timestamp,
+        name=metadata["data_description"].get("name"),
+        ip_detection=def_ip_detection_parameters,
+        ip_registrations=[ip_reg_translation, ip_reg_affine],
+        n5_to_zarr=n5_to_zarr,
+        zarr_multiscale=zarr_multiscale,
+    )
+
+    return processing_manifest
+
+
+def upload_manifest(args, manifest: ExaspimProcessingPipeline):
+    """Write out the given manifest as a json file and upload to S3"""
+    s3 = boto3.client("s3")  # Authentication should be available in the environment
+    object_name = "/".join((args.manifest_path, "exaspim_manifest.json"))
+    with open("../results/exaspim_manifest.json", "w") as f:
+        f.write(manifest.json(indent=4))
+    print(f"Uploading manifest to bucket {args.manifest_bucket_name} : {object_name}")
+    s3.upload_file("../results/exaspim_manifest.json", args.manifest_bucket_name, object_name)
+
+
+def process_args(args):
+    """Command line arguments processing"""
+
+    # Determine the pipeline timestamp
+    if args.pipeline_timestamp is None:
+        pipeline_timestamp = datetime.datetime.utcnow()
+    else:
+        pipeline_timestamp = datetime.datetime.strptime(args.pipeline_timestamp, "%Y-%m-%d_%H-%M-%S")
+
+    args.pipeline_timestamp = pipeline_timestamp
+    args.fname_timestamp = get_fname_timestamp(pipeline_timestamp)
+
+    # Get raw dataset bucket and path
+    url = urlparse(args.exaspim_data_uri)
+    args.dataset_bucket_name = url.netloc
+    # Includes the last element and optionally other path elements
+    # No slashes at the beginning and end
+    args.dataset_prefix = url.path.strip("/")
+    args.dataset_name = os.path.basename(args.dataset_prefix)  # Only the last entry as "name"
+    # Get manifest bucket and path and 'directory' name
+    url = urlparse(args.manifest_prefix_uri)
+    args.manifest_bucket_name = url.netloc
+    manifest_name = "exaspim_manifest_{}".format(args.fname_timestamp)
+    # S3 "directory" path for uploading generated manifest file
+    args.manifest_name = manifest_name
+    args.manifest_path = url.path.strip("/") + "/" + manifest_name
+
+
+def capsule_main():
+    """Main entry point for trigger capsule."""
+    args = parse_args()  # To get help before the error messages
+
+    cwd = os.getcwd()
+    if os.path.basename(cwd) != "code":
+        # We don't know where we are in the capsule environment
+        raise RuntimeError("This program should be run from the 'code' capsule folder.")
+
+    if "CODEOCEAN_DOMAIN" not in os.environ or "CUSTOM_KEY" not in os.environ:
+        raise RuntimeError(
+            "CODEOCEAN_DOMAIN and CUSTOM_KEY variables must be set with CO API access credentials"
+        )
+
+    process_args(args)
+    metadata = get_dataset_metadata(args)
+
+    # Get code ocean creds
+    # co_cred = CodeOceanCredentials(
+    #     domain=os.environ["CODEOCEAN_DOMAIN"], token=os.environ["CUSTOM_KEY"]
+    # ).dict()
+
+    # Creating the API Client
+    co_api = CodeOceanClient(domain=os.environ["CODEOCEAN_DOMAIN"], token=os.environ["CUSTOM_KEY"])
+    # validate_s3_location(args, metadata)
+    raw_data_asset_id = register_raw_dataset_as_CO_data_asset(args, metadata, co_api)
+    manifest = create_exaspim_manifest(args, metadata)
+    upload_manifest(args, manifest)
+    manifest_data_asset_id = register_manifest_as_CO_data_asset(args, co_api)
+    if args.xml_capsule_id:
+      run_xml_capsule(args, co_api, raw_data_asset_id)
+    if args.ij_capsule_id:
+        start_ij_capsule(args, co_api, raw_data_asset_id, manifest_data_asset_id)
+    

--- a/src/aind_exaspim_pipeline_utils/trigger/capsule.py
+++ b/src/aind_exaspim_pipeline_utils/trigger/capsule.py
@@ -24,14 +24,14 @@ from ..exaspim_manifest import (
 )
 
 
-def get_fname_timestamp(stamp: Optional[datetime.datetime] = None) -> str:
+def get_fname_timestamp(stamp: Optional[datetime.datetime] = None) -> str:  # pragma: no cover
     """Get the time in the format used in the file names YYYY-MM-DD_HH-MM-SS"""
     if stamp is None:
         stamp = datetime.datetime.utcnow()
     return stamp.strftime("%Y-%m-%d_%H-%M-%S")
 
 
-def parse_args() -> argparse.Namespace:
+def parse_args() -> argparse.Namespace:  # pragma: no cover
     """Command line arguments of the trigger capsule"""
     parser = argparse.ArgumentParser(
         prog="run_trigger_capsule",
@@ -51,7 +51,7 @@ def parse_args() -> argparse.Namespace:
 
 
 # TODO: Use validated model, once stable
-def get_dataset_metadata(args) -> dict:
+def get_dataset_metadata(args) -> dict:  # pragma: no cover
     """Get the metadata of the exaspim dataset from S3.
 
     Also gets the acquisition.json if available and puts into the dict.
@@ -83,7 +83,7 @@ def get_dataset_metadata(args) -> dict:
     return metadata
 
 
-def validate_s3_location(args, meta):
+def validate_s3_location(args, meta):  # pragma: no cover
     """Get the last data_process and check whether we're at its output location"""
     lastproc: DataProcess = DataProcess.parse_obj(meta["processing"]["data_processes"][-1])
     meta_url = urlparse(lastproc.output_location)
@@ -97,7 +97,7 @@ def wait_for_data_availability(
         data_asset_id: str,
         timeout_seconds: int = 300,
         pause_interval=10,
-):
+):  # pragma: no cover
     """
     There is a lag between when a register data request is made and when the
     data is available to be used in a capsule.
@@ -137,7 +137,7 @@ def wait_for_compute_completion(
         compute_id: str,
         timeout_seconds: int = 300,
         pause_interval: int = 5,
-):
+):  # pragma: no cover
     """
     Parameters
     ----------
@@ -168,7 +168,7 @@ def wait_for_compute_completion(
     return run_status
 
 
-def make_data_viewable(co_client: CodeOceanClient, data_asset_id: str):
+def make_data_viewable(co_client: CodeOceanClient, data_asset_id: str):  # pragma: no cover
     """
     Makes a registered dataset viewable
 
@@ -188,7 +188,7 @@ def make_data_viewable(co_client: CodeOceanClient, data_asset_id: str):
     print(f"Data asset viewable to everyone: {update_data_perm_response}")
 
 
-def register_raw_dataset_as_CO_data_asset(args, meta, co_api):
+def register_raw_dataset_as_CO_data_asset(args, meta, co_api):  # pragma: no cover
     """Register the dataset as a linked S3 data asset in CO"""
     # TODO: Current metadata fails with schema validation
     # data_description: DataDescription = DataDescription.parse_obj(meta["data_description"])
@@ -214,7 +214,7 @@ def register_raw_dataset_as_CO_data_asset(args, meta, co_api):
     return data_asset_id
 
 
-def register_manifest_as_CO_data_asset(args, co_api):
+def register_manifest_as_CO_data_asset(args, co_api):  # pragma: no cover
     """Register the manifest as a linked S3 data asset in CO"""
     # TODO: Current metadata fails with schema validation
     # data_description: DataDescription = DataDescription.parse_obj(meta["data_description"])
@@ -239,7 +239,7 @@ def register_manifest_as_CO_data_asset(args, co_api):
     return data_asset_id
 
 
-def start_pipeline(args, co_api, manifest_data_asset_id):
+def start_pipeline(args, co_api, manifest_data_asset_id):  # pragma: no cover
     """Mount the manifest and start a CO pipeline or capsule."""
     # mount
     data_assets = [
@@ -259,7 +259,7 @@ def start_pipeline(args, co_api, manifest_data_asset_id):
     time.sleep(5)
 
 
-def run_xml_capsule(args, co_api, raw_data_asset_id):
+def run_xml_capsule(args, co_api, raw_data_asset_id):  # pragma: no cover
     """Run the xml generator capsule.
 
       * Attach the raw_data_asset_id as exaspim_dataset to the capsule
@@ -298,7 +298,7 @@ def run_xml_capsule(args, co_api, raw_data_asset_id):
     s3.upload_file("../results/dataset.xml", args.manifest_bucket_name, object_name)
 
 
-def start_ij_capsule(args, co_api, raw_data_asset_id, manifest_data_asset_id):
+def start_ij_capsule(args, co_api, raw_data_asset_id, manifest_data_asset_id):  # pragma: no cover
     """Start the IJ wrapper capsule.
     """
     data_assets = [
@@ -317,7 +317,7 @@ def start_ij_capsule(args, co_api, raw_data_asset_id, manifest_data_asset_id):
     print(f"Run response: {run_response}")
 
 
-def get_channel_name(metadata: dict):
+def get_channel_name(metadata: dict):  # pragma: no cover
     """Get the channel name from the metadata json"""
     if 'acquisition' in metadata:
         acq = metadata['acquisition']
@@ -328,7 +328,7 @@ def get_channel_name(metadata: dict):
     return ch_name
 
 
-def create_exaspim_manifest(args, metadata):
+def create_exaspim_manifest(args, metadata):  # pragma: no cover
     """Create exaspim manifest from the metadata that we have"""
     # capsule_xml_path = "../data/manifest/dataset.xml"
     def_ij_wrapper_parameters: IJWrapperParameters = IJWrapperParameters(memgb=106, parallel=32)
@@ -400,7 +400,7 @@ def create_exaspim_manifest(args, metadata):
     return processing_manifest
 
 
-def upload_manifest(args, manifest: ExaspimProcessingPipeline):
+def upload_manifest(args, manifest: ExaspimProcessingPipeline):  # pragma: no cover
     """Write out the given manifest as a json file and upload to S3"""
     s3 = boto3.client("s3")  # Authentication should be available in the environment
     object_name = "/".join((args.manifest_path, "exaspim_manifest.json"))
@@ -410,7 +410,7 @@ def upload_manifest(args, manifest: ExaspimProcessingPipeline):
     s3.upload_file("../results/exaspim_manifest.json", args.manifest_bucket_name, object_name)
 
 
-def process_args(args):
+def process_args(args):  # pragma: no cover
     """Command line arguments processing"""
 
     # Determine the pipeline timestamp
@@ -438,7 +438,7 @@ def process_args(args):
     args.manifest_path = url.path.strip("/") + "/" + manifest_name
 
 
-def capsule_main():
+def capsule_main():  # pragma: no cover
     """Main entry point for trigger capsule."""
     args = parse_args()  # To get help before the error messages
 


### PR DESCRIPTION
 * Add new entry point for manifest configuration.
 * Make argschema usage obsolete.
 * Add ip detection and registration parameters to manifest.
 * Trigger capsule: Get metadata.json from S3
 * Add manifest creation with default parameters.
 * Add S3 credentials from environment variable.
 * Remove data status model. Remove manifest and processing pipeline distinction. Manifest updates.
 * Fix schema, replace tuple for list. Tuple is fixed length at declaration.
 * Download capsule run results via the direct CO link.
 * Change to UTC time.
 * Remove xml from IPRegistrationParameters - this is now a hard-wired and dataset independent mount location.
 * Add channel name deduction from acquisition metadata.
 * Fix minor manifest schema inconsistencies.
 * Rename exaspim_acquisition to acquisition to be in line with the data naming conventions.