### PR TITLE
feat: Update exaspim trigger capsule for current CO release. Add alignment data product.

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10' ]
+        python-version: [ '3.10' ]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,10 +18,12 @@ dynamic = ["version"]
 
 dependencies = [
     'argschema',
+    's3fs',
     'pydantic',
     'psutil',
     'aind-data-schema',
-    'aind-codeocean-api'
+    'aind-codeocean-api==0.3.0',
+    'aind-ng-link',
 ]
 
 [project.optional-dependencies]
@@ -42,7 +44,7 @@ n5tozarr = [
     'distributed',
     'zarr',
     'numcodecs',
-    'aind-data-transfer[full]',
+    'aind-data-transfer[full]==0.32.0',
     # missing dependencies from aind-data-transfer[full]
     # These supposed to be installed by post_install.sh
 #    'hdf5plugin',

--- a/src/aind_exaspim_pipeline_utils/n5tozarr/n5tozarr_da.py
+++ b/src/aind_exaspim_pipeline_utils/n5tozarr/n5tozarr_da.py
@@ -401,7 +401,7 @@ def get_zarr_multiscale_metadata(config: dict):  # pragma: no cover
 
 def get_n5tozarr_metadata(config: dict):  # pragma: no cover
     """Initiate metadata instance with current timestamp and configuration."""
-    t = datetime.datetime.utcnow()
+    t = datetime.datetime.now()
     dp = DataProcess(
         name=ProcessName.FILE_CONVERSION,
         software_version=config["capsule"]["version"],
@@ -426,7 +426,7 @@ def set_metadata_done(meta: DataProcess) -> None:  # pragma: no cover
     meta: DataProcess
       Capsule metadata instance.
     """
-    t = datetime.datetime.utcnow()
+    t = datetime.datetime.now()
     meta.end_date_time = t
     meta.notes = "DONE"
 

--- a/src/aind_exaspim_pipeline_utils/qc/bigstitcher_log_edge_analysis.py
+++ b/src/aind_exaspim_pipeline_utils/qc/bigstitcher_log_edge_analysis.py
@@ -32,7 +32,7 @@ def get_unfitted_tile_pairs(lines: Iterable[str]) -> List[List[Tuple[int, int]]]
     for line in lines:
         line = line.strip()
         # RANSAC result lines
-        m = re.match('.*\\[TP=(\\d+) ViewId=(\\d+) >>> TP=(\\d+) ViewId=(\\d+)\\]: (\\w+)', line)
+        m = re.match(".*\\[TP=(\\d+) ViewId=(\\d+) >>> TP=(\\d+) ViewId=(\\d+)\\]: (\\w+)", line)
         if m:
             if m.group(5) == "NO" or m.group(5) == "Not":  # Failed RANSAC
                 a = int(m.group(4))
@@ -74,15 +74,15 @@ def create_ascii_visualization(pairs: Iterable[Tuple[int, int]]) -> str:  # prag
     -------
     r : Multi-line string
     """
-    A = np.zeros(dtype='U', shape=(5, 9))
+    A = np.zeros(dtype="U", shape=(5, 9))
     A.fill(".")
     A[0::2, 0::2] = np.array(list("0369c147ad258be"), dtype="U").reshape((3, 5))
     for p in pairs:
         a, b = p
         if b - a == 3:
-            A[(a % 3) * 2, (a // 3) * 2 + 1] = 'X'
+            A[(a % 3) * 2, (a // 3) * 2 + 1] = "X"
         elif b - a == 1:
-            A[(a % 3) * 2 + 1, (a // 3) * 2] = 'X'
+            A[(a % 3) * 2 + 1, (a // 3) * 2] = "X"
         else:
             raise ValueError
     return "\n".join(" ".join(x[::-1]) for x in A)
@@ -92,7 +92,7 @@ def print_visualization(blocks, file=None):  # pragma: no cover
     """Print ascii visualization of edges for multiple blocks."""
 
     for i, pairs in enumerate(blocks):
-        print(f"Registration block {i + 1:1d}:", file=file)
+        print(f"Log block {i:1d}:", file=file)
         print("=====================", file=file)
         print(create_ascii_visualization(pairs), file=file)
         print(file=file)

--- a/src/aind_exaspim_pipeline_utils/qc/create_ng_link.py
+++ b/src/aind_exaspim_pipeline_utils/qc/create_ng_link.py
@@ -1,0 +1,164 @@
+"""Create Neuroglancer links for the alignments."""
+
+# Copied from Jonathan's NG link generator capsule code
+
+import json
+from pathlib import Path
+from urllib.parse import urlparse
+
+from ng_link import NgState, link_utils, xml_parsing
+import numpy as np
+import os
+
+
+def read_json(json_path: str) -> dict:  # pragma: no cover
+    """Read a json file and return a dict."""
+    with open(json_path) as f:
+        return json.load(f)
+
+
+def get_tile_positions(dataset_path: str):  # pragma: no cover
+    """Get the tile positions from the zattrs files."""
+    tile_positions = {}
+    for tile_path in Path(dataset_path).iterdir():
+        if tile_path.name == ".zgroup":
+            continue
+
+        zattrs_file = tile_path / ".zattrs"
+        zattrs_json = read_json(zattrs_file)
+
+        scale = zattrs_json["multiscales"][0]["datasets"][0]["coordinateTransformations"][0]["scale"]
+        translation = zattrs_json["multiscales"][0]["datasets"][0]["coordinateTransformations"][1][
+            "translation"
+        ]
+
+        scale = np.array(scale[2:][::-1])
+        translation = np.array(translation[2:][::-1])
+        translation /= scale
+        translation = np.round(translation, 4)
+
+        tile_positions[tile_path.name] = translation
+
+    return tile_positions
+
+
+def create_ng_link(
+    dataset_uri: str,
+    alignment_output_uri: str,
+    xml_path: str = "../results/bigstitcher.xml",
+    output_json: str = "../results/ng/process_output.json",
+):  # pragma: no cover
+    """ "Create a Neuroglancer json file and link file for the given alignment solution.
+
+    The link is appended to the file ../results/ng/ng_link.txt.
+
+    Parameters
+    ----------
+    dataset_uri: str
+        URI to the tiled dataset
+    xml_path: str
+        Path to the BigStitcher output xml file with the alignment result.
+    output_json: str
+        Path and file name to the Neuroglancer json file will be saved in the capsule.
+    """
+    dataset_uri = dataset_uri.rstrip("/")
+    # Never put trailing slashes
+    # output_uri = 's3://aind-open-data/exaSPIM_659146_2023-11-10_14-02-06/SPIM.ome.zarr'
+    # xml_path = '/root/capsule/data/2023-11-27_s18_th03_l150k_659146/bigstitcher_2023-11-27.xml'
+    # dataset_path = '/root/capsule/data/exaSPIM_659146_2023-11-10_14-02-06/SPIM.ome.zarr'
+    # alignment_run = '2023-11-27'  # Will be attached to upload name: process_output_{alignment_run}.json
+    # output_json_path = '/results'
+
+    # XML info
+    vox_sizes: tuple[float, float, float] = xml_parsing.extract_tile_vox_size(xml_path)
+    tile_paths: dict[int, str] = xml_parsing.extract_tile_paths(xml_path)
+    tile_transforms: dict[int, list[dict]] = xml_parsing.extract_tile_transforms(xml_path)
+
+    # Color info
+    channel: int = link_utils.extract_channel_from_tile_path(tile_paths[0])
+    hex_val: int = link_utils.wavelength_to_hex(channel)
+    hex_str = f"#{str(hex(hex_val))[2:]}"
+
+    # Zattrs info
+    zattrs_positions = get_tile_positions("../data/exaspim_dataset/SPIM.ome.zarr")
+
+    # Update Translation -- undo zattrs transform
+    for tile_id, tf in tile_transforms.items():
+        t_path = tile_paths[tile_id]
+        zattrs_offset = zattrs_positions[t_path]
+
+        nums = [float(val) for val in tf[0]["affine"].split(" ")]
+        nums[3] = nums[3] - zattrs_offset[0]
+        nums[7] = nums[7] - zattrs_offset[1]
+        nums[11] = nums[11] - zattrs_offset[2]
+
+        tf[0]["affine"] = "".join(f"{n} " for n in nums)
+        tf[0]["affine"] = tf[0]["affine"].strip()
+
+        tile_transforms[tile_id] = tf
+
+    net_transforms: dict[int, np.ndarray] = link_utils.calculate_net_transforms(tile_transforms)
+
+    # Generate input config
+    layers = []  # Neuroglancer Tabs
+    input_config = {
+        "dimensions": {
+            "x": {"voxel_size": vox_sizes[0], "unit": "microns"},
+            "y": {"voxel_size": vox_sizes[1], "unit": "microns"},
+            "z": {"voxel_size": vox_sizes[2], "unit": "microns"},
+            "c'": {"voxel_size": 1, "unit": ""},
+            "t": {"voxel_size": 0.001, "unit": "seconds"},
+        },
+        "layers": layers,
+        "showScaleBar": False,
+        "showAxisLines": False,
+    }
+
+    sources = []  # Tiles within tabs
+    layers.append(
+        {
+            "type": "image",  # Optional
+            "source": sources,
+            "channel": 0,  # Optional
+            "shaderControls": {"normalized": {"range": [0, 200]}},  # Optional  # Exaspim has low HDR
+            "shader": {
+                "color": hex_str,
+                "emitter": "RGB",
+                "vec": "vec3",
+            },
+            "visible": True,  # Optional
+            "opacity": 1,
+            "name": f"CH_{channel}",
+            "blend": "default",
+        }
+    )
+
+    for tile_id, _ in enumerate(net_transforms):
+        net_tf = net_transforms[tile_id]
+        t_path = tile_paths[tile_id]
+
+        url = f"{dataset_uri}/{t_path}"
+        final_transform = link_utils.convert_matrix_3x4_to_5x6(net_tf)
+
+        sources.append({"url": url, "transform_matrix": final_transform.tolist()})
+
+    ng_dir, json_name = os.path.split(output_json)
+    if ng_dir:
+        os.makedirs(ng_dir, exist_ok=True)
+    url = urlparse(dataset_uri)
+    if url.scheme != "s3":
+        raise ValueError(f"Dataset URI must be an S3 URI, got {dataset_uri}")
+    bucket_name = url.netloc
+
+    # Generate the link
+    neuroglancer_link = NgState(
+        input_config=input_config,
+        mount_service="s3",
+        bucket_path=bucket_name,
+        output_json=ng_dir,
+        json_name=json_name,
+    )
+    neuroglancer_link.save_state_as_json()
+    print(neuroglancer_link.get_url_link())
+    with open("../results/ng/ng_link.txt", "a") as f:
+        print(f"https://neuroglancer-demo.appspot.com/#!{alignment_output_uri}/ng/{json_name}", file=f)

--- a/src/aind_exaspim_pipeline_utils/trigger/capsule.py
+++ b/src/aind_exaspim_pipeline_utils/trigger/capsule.py
@@ -2,8 +2,10 @@
 
 import argparse
 import datetime
+import logging
 import os
 import time
+import re
 from typing import Optional
 
 import boto3
@@ -11,10 +13,14 @@ import json
 from urllib.parse import urlparse
 import urllib.request
 
+import botocore.exceptions
 from aind_codeocean_api.codeocean import CodeOceanClient
-from aind_data_schema import DataProcess
+from aind_codeocean_api.models.computations_requests import ComputationDataAsset
+
+from aind_trigger_codeocean.pipelines import CapsuleJob, RegisterAindData
 
 from ..exaspim_manifest import (
+    XMLCreationParameters,
     IJWrapperParameters,
     IPDetectionParameters,
     IPRegistrationParameters,
@@ -23,11 +29,15 @@ from ..exaspim_manifest import (
     ZarrMultiscaleParameters,
 )
 
+logging.basicConfig(format="%(asctime)s %(message)s", datefmt="%Y-%m-%d %H:%M")
+logger = logging.getLogger("exaspim_trigger")
+logger.setLevel(logging.INFO)
 
-def get_fname_timestamp(stamp: Optional[datetime.datetime] = None) -> str:  # pragma: no cover
+
+def get_fname_timestamp(stamp: Optional[datetime.datetime] = None) -> str:
     """Get the time in the format used in the file names YYYY-MM-DD_HH-MM-SS"""
-    if stamp is None:
-        stamp = datetime.datetime.utcnow()
+    if stamp is None:  # pragma: no cover
+        stamp = datetime.datetime.now()
     return stamp.strftime("%Y-%m-%d_%H-%M-%S")
 
 
@@ -37,59 +47,114 @@ def parse_args() -> argparse.Namespace:  # pragma: no cover
         prog="run_trigger_capsule",
         description="This program prepares the CO environment and launches the exaSPIM processing pipeline",
     )
-    parser.add_argument("--pipeline_id", help="CO pipeline id to launch")
+    # parser.add_argument("--pipeline_id", help="CO pipeline id to launch")
     parser.add_argument(
-        "exaspim_data_uri", help="S3 URI Top-level location of exaSPIM " "dataset in aind-open-data"
+        "--exaspim_data_uri",
+        help="S3 URI Top-level location of input exaSPIM " "dataset in aind-open-data",
+        required=True,
     )
-    parser.add_argument("manifest_prefix_uri", help="S3 prefix URI for processing manifest upload")
-    parser.add_argument("--pipeline_timestamp", help="Pipeline timestamp to be appended to folder names. "
-                                                     "Defaults to current UTC time as YYYY-MM-DD_HH-MM-SS")
+    parser.add_argument(
+        "--raw_data_uri",
+        help="S3 URI Top-level location of input exaSPIM"
+             "dataset in aind-open-data if different from exaspim_data_uri "
+             "(ie. flat-fielded)",
+    )
+    parser.add_argument(
+        "--manifest_output_prefix_uri", help="S3 prefix URI for processing manifest upload", required=True
+    )
+    parser.add_argument(
+        "--pipeline_timestamp",
+        help="Pipeline timestamp to be appended to folder names. "
+             "Defaults to current local time as YYYY-MM-DD_HH-MM-SS",
+    )
     parser.add_argument("--xml_capsule_id", help="XML converter capsule id. Runs it if present.")
     parser.add_argument("--ij_capsule_id", help="ImageJ wrapper capsule id. Starts it if present.")
     args = parser.parse_args()
     return args
 
 
+def get_s3_file(bucket_name: str, object_name: str, local_file: str):  # pragma: no cover
+    """Download a file from S3"""
+    s3 = boto3.client("s3")  # Authentication should be available in the environment
+    logger.info(f"Downloading from bucket {bucket_name} : {object_name}")
+    try:
+        s3.download_file(bucket_name, object_name, local_file)
+    except botocore.exceptions.ClientError as e:
+        if e.response["Error"]["Code"] == "404":
+            logger.warning(f"File {object_name} not found in {bucket_name}. Skipping")
+            return False
+        else:
+            raise
+    return True
+
+
 # TODO: Use validated model, once stable
 def get_dataset_metadata(args) -> dict:  # pragma: no cover
-    """Get the metadata of the exaspim dataset from S3.
+    """Get the metadata jsons of the exaspim dataset from S3.
 
-    Also gets the acquisition.json if available and puts into the dict.
+    Get `data_description`, `subject.json` and `acquisition.json` from the data location.
     """
+    metadata = {}
 
-    s3 = boto3.client("s3")  # Authentication should be available in the environment
+    # acquisiton and exaSPIM_acquisition must be the last two
+    files = ["data_description.json", "subject.json", "acquisition.json", "exaSPIM_acquisition.json"]
+    for f in files:
+        object_name = "/".join((args.input_dataset_prefix, f))
+        # Try the input dataset
+        if not get_s3_file(args.input_dataset_bucket_name, object_name, f"../results/{f}"):
+            logger.warning(f"Metadata file {f} not found in {args.input_dataset_prefix}")
+            object_name = "/".join((args.raw_dataset_prefix, f))
+            if not get_s3_file(args.raw_dataset_bucket_name, object_name, f"../results/{f}"):
+                logger.warning(f"Metadata file not found {f} in {args.raw_dataset_prefix}. Skipping.")
+                continue
 
-    object_name = "/".join((args.dataset_prefix, "metadata.json"))
+        with open(f"../results/{f}", "r") as jfile:
+            data = json.load(jfile)
+            metadata[os.path.splitext(f)[0]] = data
 
-    # Download the file from S3
-    print(f"Downloading from bucket {args.dataset_bucket_name} : {object_name}")
-    s3.download_file(args.dataset_bucket_name, object_name, "../results/metadata.json")
+        # If acquisition is present in the input dataset,
+        # don't try the old name in the raw dataset
+        if "acquisition" in metadata:
+            break
 
-    # Parse the JSON file
-    with open("../results/metadata.json", "r") as f:
-        metadata = json.load(f)
+    # If acquisition has its old name, rename it
+    if "exaSPIM_acquisition" in metadata:
+        metadata["acquisition"] = metadata["exaSPIM_acquisition"]
+        del metadata["exaSPIM_acquisition"]
 
-    object_name = "/".join((args.dataset_prefix, "acquisition.json"))
-    # Download the file from S3
-    print(f"Downloading from bucket {args.dataset_bucket_name} : {object_name}")
-    s3.download_file(args.dataset_bucket_name, object_name, "../results/acquisition.json")
-
-    if os.path.exists("../results/acquisition.json"):
-        with open("../results/acquisition.json", "r") as f:
-            acqdata = json.load(f)
-        if acqdata:
-            metadata['acquisition'] = acqdata
+    # Validate subject_id
+    m = re.match(r".*exaSPIM_(\w+)_\d{4}-\d{2}-\d{2}", args.input_dataset_prefix)
+    if m:
+        fname_subject_id = m.group(1)
+    if not metadata["subject"]:
+        logger.warning("No subject metadata. Using file path pattern.")
+        metadata["subject"] = {"subject_id": fname_subject_id}
+    else:
+        meta_subject_id = metadata["subject"].get("subject_id")
+        if not meta_subject_id:
+            logger.warning("Subject id is null in metadata. Using file path pattern.")
+            metadata["subject"]["subject_id"] = fname_subject_id
+        else:
+            # We have an entry in the metadata
+            if meta_subject_id != fname_subject_id:
+                raise ValueError(
+                    "The subject id in the metadata and in the file paths do not match. "
+                    f"{meta_subject_id} != {fname_subject_id}"
+                )
 
     return metadata
 
 
-def validate_s3_location(args, meta):  # pragma: no cover
-    """Get the last data_process and check whether we're at its output location"""
-    lastproc: DataProcess = DataProcess.parse_obj(meta["processing"]["data_processes"][-1])
-    meta_url = urlparse(lastproc.output_location)
-
-    if meta_url.netloc != args.dataset_bucket_name or meta_url.path.strip("/") != args.dataset_prefix:
-        raise ValueError("Output location of last DataProcess does not match with current dataset location")
+# TODO: Validate whether the location we're processing matches with the metadata given location
+# def validate_s3_location(args, meta):  # pragma: no cover
+#     """Get the last data_process and check whether we're at its output location"""
+#     lastproc: DataProcess = DataProcess.parse_obj(meta["processing"]["data_processes"][-1])
+#     meta_url = urlparse(lastproc.output_location)
+#
+#     if meta_url.netloc != args.input_dataset_bucket_name or \
+#     meta_url.path.strip("/") != args.input_dataset_prefix:
+#         raise ValueError(
+#         "Output location of last DataProcess does not match with current dataset location")
 
 
 def wait_for_data_availability(
@@ -159,8 +224,11 @@ def wait_for_compute_completion(
         if run_status.status_code != 200:
             raise RuntimeError(f"Cannot get compute status {compute_id}")
         run_status = run_status.json()
-        if run_status['state'] == 'completed' and run_status['has_results'] and \
-                run_status['end_status'] == 'succeeded':
+        if (
+                run_status["state"] == "completed"
+                and run_status["has_results"]
+                and run_status["end_status"] == "succeeded"
+        ):
             break
         print(f"Waiting loop {i_check}: {run_status}")
     else:
@@ -188,142 +256,168 @@ def make_data_viewable(co_client: CodeOceanClient, data_asset_id: str):  # pragm
     print(f"Data asset viewable to everyone: {update_data_perm_response}")
 
 
-def register_raw_dataset_as_CO_data_asset(args, meta, co_api):  # pragma: no cover
+def register_input_dataset_as_CO_data_asset(args, meta, co_client):  # pragma: no cover
     """Register the dataset as a linked S3 data asset in CO"""
-    # TODO: Current metadata fails with schema validation
-    # data_description: DataDescription = DataDescription.parse_obj(meta["data_description"])
-    tags = ["exaspim", "raw"]
 
-    # TODO: Newer version of co_api supports custom metadata entries. Fill from metadata/data_description
-    # Registering data asset
-    data_asset_reg_response = co_api.register_data_asset(
-        asset_name=args.dataset_name,
-        mount=args.dataset_name,
-        bucket=args.dataset_bucket_name,
-        prefix=args.dataset_prefix,
-        tags=tags,
+    logger.info(
+        f"Register dataset as a data asset in CO. {args.input_dataset_bucket_name} {args.input_dataset_name}"
     )
+    # Register data asset
+    data_configs = {"prefix": args.input_dataset_name, "bucket": args.input_dataset_bucket_name}
+
+    R = RegisterAindData(
+        configs=data_configs, co_client=co_client, viewable_to_everyone=True, is_public_bucket=True
+    )
+    data_asset_reg_response = R.run_job()
+
     print(data_asset_reg_response)
     response_contents = data_asset_reg_response.json()
-    print(f"Created data asset in Code Ocean: {response_contents}")
+    logger.info(f"Created data asset in Code Ocean: {response_contents}")
 
     data_asset_id = response_contents["id"]
-    # Making the created data asset available for everyone
-    make_data_viewable(co_api, data_asset_id)
 
     return data_asset_id
 
 
-def register_manifest_as_CO_data_asset(args, co_api):  # pragma: no cover
+def register_raw_dataset_as_CO_data_asset(args, meta, co_client):  # pragma: no cover
+    """Register the raw dataset as a linked S3 data asset in CO.
+
+    The raw dataset is different from the input dataset if the input dataset is flat-fielded.
+    The alignment output inherits the raw dataset's timestamp."""
+
+    logger.info(
+        f"Register dataset as a data asset in CO. {args.raw_dataset_bucket_name} {args.raw_dataset_name}"
+    )
+    # Register data asset
+    data_configs = {"prefix": args.raw_dataset_name, "bucket": args.raw_dataset_bucket_name}
+
+    R = RegisterAindData(
+        configs=data_configs, co_client=co_client, viewable_to_everyone=True, is_public_bucket=True
+    )
+    data_asset_reg_response = R.run_job()
+
+    print(data_asset_reg_response)
+    response_contents = data_asset_reg_response.json()
+    logger.info(f"Created data asset in Code Ocean: {response_contents}")
+
+    data_asset_id = response_contents["id"]
+
+    return data_asset_id
+
+
+class RegisterDataJob(CapsuleJob):  # pragma: no cover
+    """Minimalistic object to run as a CapsuleJob"""
+    def run_job(self):
+        """An empty run_job method
+
+        TODO: Move the actual job preparation and run code here.
+        """
+        pass
+
+
+def register_manifest_as_CO_data_asset(args, co_client):  # pragma: no cover
     """Register the manifest as a linked S3 data asset in CO"""
     # TODO: Current metadata fails with schema validation
     # data_description: DataDescription = DataDescription.parse_obj(meta["data_description"])
     tags = ["exaspim", "manifest"]
 
-    # TODO: Newer version of co_api supports custom metadata entries. Fill from metadata/data_description
-    # Registering data asset
-    data_asset_reg_response = co_api.register_data_asset(
+    C = RegisterDataJob(configs={}, co_client=co_client)
+    data_asset_reg_response = C.register_data(
         asset_name=args.manifest_name,
         mount="manifest",
         bucket=args.manifest_bucket_name,
         prefix=args.manifest_path,
         tags=tags,
+        viewable_to_everyone=True,
+        is_public_bucket=True,
     )
+
     response_contents = data_asset_reg_response.json()
-    print(f"Created data asset in Code Ocean: {response_contents}")
+    logger.info(f"Created data asset in Code Ocean: {response_contents}")
 
     data_asset_id = response_contents["id"]
-    # Making the created data asset available for everyone
-    make_data_viewable(co_api, data_asset_id)
 
     return data_asset_id
 
 
-def start_pipeline(args, co_api, manifest_data_asset_id):  # pragma: no cover
+def start_pipeline(args, co_client, manifest_data_asset_id):  # pragma: no cover
     """Mount the manifest and start a CO pipeline or capsule."""
     # mount
     data_assets = [
-        {"id": manifest_data_asset_id, "mount": "manifest"},
+        ComputationDataAsset(id=manifest_data_asset_id, mount="manifest"),
     ]
+    C = RegisterDataJob(configs={}, co_client=co_client)
+    run_response = C.run_capsule(capsule_id=args.ij_capsule_id, data_assets=data_assets)
 
-    # dumped_parameters = json.dumps(job_configs)
-    # print(dumped_parameters)
-    # Executing capsule attaching new data asset
-    run_response = co_api.run_capsule(
-        capsule_id=args.pipeline_id,
-        data_assets=data_assets,
-        parameters=None,
-    )
-
-    print(f"Run response: {run_response.json()}")
+    logger.info(f"Run response: {run_response.json()}")
     time.sleep(5)
 
 
-def run_xml_capsule(args, co_api, raw_data_asset_id):  # pragma: no cover
+def run_xml_capsule(args, co_client, input_data_asset_id, manifest_data_asset_id):  # pragma: no cover
     """Run the xml generator capsule.
 
-      * Attach the raw_data_asset_id as exaspim_dataset to the capsule
-      * Run the capsule and waits for completion.
-      * Download output.xml and upload it to the manifest location.
+    * Attach the input_data_asset_id as exaspim_dataset to the capsule
+    * Run the capsule and waits for completion.
+    * Download output.xml and upload it to the manifest location.
     """
+    logger.info("Running xml creator capsule")
     data_assets = [
-        {"id": raw_data_asset_id, "mount": "exaspim_dataset"},
+        ComputationDataAsset(id=input_data_asset_id, mount="exaspim_dataset"),
+        ComputationDataAsset(id=manifest_data_asset_id, mount="manifest"),
     ]
-
-    # dumped_parameters = json.dumps(job_configs)
-    # print(dumped_parameters)
-    # Executing capsule attaching new data asset
-    run_response = co_api.run_capsule(
-        capsule_id=args.xml_capsule_id,
-        data_assets=data_assets,
-        parameters=None,
-    )
+    C = RegisterDataJob(configs={}, co_client=co_client)
+    run_response = C.run_capsule(capsule_id=args.xml_capsule_id, data_assets=data_assets, pause_interval=10)
 
     run_response = run_response.json()
-    compute_id = run_response["id"]
 
-    print(f"Run response: {run_response}")
-    wait_for_compute_completion(co_api, compute_id)
-
-    result_response = co_api.get_result_file_download_url(run_response["id"], "output.xml")
+    result_response = co_client.get_result_file_download_url(run_response["id"], "output.xml")
     result = result_response.json()
-    if result_response.status_code != 200 or 'url' not in result:
+    if result_response.status_code != 200 or "url" not in result:
         raise RuntimeError("Cannot get xml capsule result")
-    print(f"Result query response: {result}")
-    urllib.request.urlretrieve(result['url'], "../results/dataset.xml")
+    logger.info(f"Result query response: {result}")
+    urllib.request.urlretrieve(result["url"], "../results/dataset.xml")
     # Upload
     s3 = boto3.client("s3")  # Authentication should be available in the environment
     object_name = "/".join((args.manifest_path, "dataset.xml"))
-    print(f"Uploading to bucket {args.manifest_bucket_name} : {object_name}")
+    logger.info(f"Uploading to bucket {args.manifest_bucket_name} : {object_name}")
     s3.upload_file("../results/dataset.xml", args.manifest_bucket_name, object_name)
 
 
-def start_ij_capsule(args, co_api, raw_data_asset_id, manifest_data_asset_id):  # pragma: no cover
-    """Start the IJ wrapper capsule.
-    """
+def start_ij_capsule(args, co_client, input_data_asset_id, manifest_data_asset_id):  # pragma: no cover
+    """Start the IJ wrapper capsule."""
+    logger.info("Running IJ wrapper capsule")
     data_assets = [
-        {"id": raw_data_asset_id, "mount": "exaspim_dataset"},
-        {"id": manifest_data_asset_id, "mount": "manifest"}
+        ComputationDataAsset(id=input_data_asset_id, mount="exaspim_dataset"),
+        ComputationDataAsset(id=manifest_data_asset_id, mount="manifest"),
     ]
 
-    print("Starting IJ wrapper capsule")
-    run_response = co_api.run_capsule(
+    C = RegisterDataJob(configs={}, co_client=co_client)
+    C.run_capsule(
         capsule_id=args.ij_capsule_id,
         data_assets=data_assets,
-        parameters=None,
+        pause_interval=30,
+        timeout_seconds=3600 * 100,
     )
-
-    run_response = run_response.json()
-    print(f"Run response: {run_response}")
+    logger.info("IJ capsule finished. Registering alignment dataset as a data asset in CO")
+    # Create data asset from the output_uri location
+    C.register_data(
+        asset_name=args.alignment_dataset_name,
+        mount=args.alignment_dataset_name,
+        bucket=args.input_dataset_bucket_name,
+        prefix=args.alignment_dataset_name,
+        tags=["exaspim", "alignment"],
+        viewable_to_everyone=True,
+        is_public_bucket=True,
+    )
 
 
 def get_channel_name(metadata: dict):  # pragma: no cover
     """Get the channel name from the metadata json"""
-    if 'acquisition' in metadata:
-        acq = metadata['acquisition']
+    if "acquisition" in metadata:
+        acq = metadata["acquisition"]
         ch_name = acq["tiles"][0]["channel"]["channel_name"]
     else:
-        print("Warning: Cannot get channel name, defaults to ch488")
+        logger.warning("Cannot get channel name, defaults to ch488")
         ch_name = "ch488"
     return ch_name
 
@@ -331,7 +425,10 @@ def get_channel_name(metadata: dict):  # pragma: no cover
 def create_exaspim_manifest(args, metadata):  # pragma: no cover
     """Create exaspim manifest from the metadata that we have"""
     # capsule_xml_path = "../data/manifest/dataset.xml"
-    def_ij_wrapper_parameters: IJWrapperParameters = IJWrapperParameters(memgb=106, parallel=32)
+    def_ij_wrapper_parameters: IJWrapperParameters = IJWrapperParameters(
+        memgb=106, parallel=32, input_uri=args.exaspim_data_uri, output_uri=args.alignment_output_uri
+    )
+
     def_ip_detection_parameters: IPDetectionParameters = IPDetectionParameters(
         # dataset_xml=capsule_xml_path,  # For future S3 path
         IJwrap=def_ij_wrapper_parameters,
@@ -372,25 +469,26 @@ def create_exaspim_manifest(args, metadata):  # pragma: no cover
     )
 
     ch_name = get_channel_name(metadata)
-    # TODO: Generate plausible URIs
+    # Even the flat-fielded fusions goes with the raw dataset prefix
     n5_to_zarr: N5toZarrParameters = N5toZarrParameters(
         voxel_size_zyx=(1.0, 0.748, 0.748),
-        input_uri=f"s3://{args.dataset_bucket_name}/{args.dataset_prefix}"
-                  f"_fusion_{args.fname_timestamp}/fused.n5/{ch_name}/",
-        output_uri=f"s3://{args.dataset_bucket_name}/{args.dataset_prefix}"
-                   f"_fusion_{args.fname_timestamp}/fused.zarr/",
+        input_uri=f"s3://{args.fusion_output_bucket}/{args.fusion_output_prefix}/fused.n5/ch{ch_name}/",
+        output_uri=f"s3://{args.fusion_output_bucket}/{args.fusion_output_prefix}/fused.zarr/",
     )
 
     zarr_multiscale: ZarrMultiscaleParameters = ZarrMultiscaleParameters(
         voxel_size_zyx=(1.0, 0.748, 0.748),
-        input_uri=f"s3://{args.dataset_bucket_name}/{args.dataset_prefix}"
-                  f"_fusion_{args.fname_timestamp}/fused.zarr/",
+        input_uri=f"s3://{args.fusion_output_bucket}/{args.fusion_output_prefix}/fused.zarr/",
     )
+
+    xml_creation: XMLCreationParameters = XMLCreationParameters(ch_name=ch_name)
 
     processing_manifest: ExaspimProcessingPipeline = ExaspimProcessingPipeline(
         creation_time=args.pipeline_timestamp,
         pipeline_suffix=args.fname_timestamp,
+        subject_id=metadata["subject"].get("subject_id"),
         name=metadata["data_description"].get("name"),
+        xml_creation=xml_creation,
         ip_detection=def_ip_detection_parameters,
         ip_registrations=[ip_reg_translation, ip_reg_affine],
         n5_to_zarr=n5_to_zarr,
@@ -400,13 +498,31 @@ def create_exaspim_manifest(args, metadata):  # pragma: no cover
     return processing_manifest
 
 
+def create_and_upload_emr_config(args, metadata, manifest: ExaspimProcessingPipeline):  # pragma: no cover
+    """Create EMR command line parameters for the fusion of the present alignment run."""
+    ch_name = get_channel_name(metadata)
+    config = (
+        f"-x, {args.alignment_output_uri}/"
+        f"bigstitcher_emr_{manifest.subject_id}_{manifest.pipeline_suffix}.xml,\n"
+        f"--outS3Bucket, {args.fusion_output_bucket}, -o, /{args.fusion_output_prefix}/fused.n5,\n"
+        f"-d, /ch{ch_name}/s0, --storage, N5, --UINT16, --minIntensity=0, "
+        f"--maxIntensity=65535, --preserveAnisotropy\n"
+    )
+    with open("../results/emr_fusion_config.txt", "w") as f:
+        f.write(config)
+    logger.info("Uploading emr_fusion_config.txt to bucket {}".format(args.manifest_bucket_name))
+    s3 = boto3.client("s3")  # Authentication should be available in the environment
+    object_name = "/".join((args.manifest_path, "emr_fusion_config.txt"))
+    s3.upload_file("../results/emr_fusion_config.txt", args.manifest_bucket_name, object_name)
+
+
 def upload_manifest(args, manifest: ExaspimProcessingPipeline):  # pragma: no cover
     """Write out the given manifest as a json file and upload to S3"""
     s3 = boto3.client("s3")  # Authentication should be available in the environment
     object_name = "/".join((args.manifest_path, "exaspim_manifest.json"))
     with open("../results/exaspim_manifest.json", "w") as f:
         f.write(manifest.json(indent=4))
-    print(f"Uploading manifest to bucket {args.manifest_bucket_name} : {object_name}")
+    logger.info(f"Uploading manifest to bucket {args.manifest_bucket_name} : {object_name}")
     s3.upload_file("../results/exaspim_manifest.json", args.manifest_bucket_name, object_name)
 
 
@@ -415,7 +531,7 @@ def process_args(args):  # pragma: no cover
 
     # Determine the pipeline timestamp
     if args.pipeline_timestamp is None:
-        pipeline_timestamp = datetime.datetime.utcnow()
+        pipeline_timestamp = datetime.datetime.now()
     else:
         pipeline_timestamp = datetime.datetime.strptime(args.pipeline_timestamp, "%Y-%m-%d_%H-%M-%S")
 
@@ -424,24 +540,42 @@ def process_args(args):  # pragma: no cover
 
     # Get raw dataset bucket and path
     url = urlparse(args.exaspim_data_uri)
-    args.dataset_bucket_name = url.netloc
+    args.input_dataset_bucket_name = url.netloc
     # Includes the last element and optionally other path elements
-    # No slashes at the beginning and end
-    args.dataset_prefix = url.path.strip("/")
-    args.dataset_name = os.path.basename(args.dataset_prefix)  # Only the last entry as "name"
+    # No slashes at the beginning and end of prefixes
+    args.input_dataset_prefix = url.path.strip("/")
+    args.input_dataset_name = os.path.basename(args.input_dataset_prefix)  # Only the last entry as "name"
+    if args.raw_data_uri:
+        # There is a separate raw dataset given - the input dataset is flat-fielded
+        url = urlparse(args.raw_data_uri)
+        args.raw_dataset_bucket_name = url.netloc
+        args.raw_dataset_prefix = url.path.strip("/")  # The path including the raw dataset name
+        args.raw_dataset_name = os.path.basename(args.raw_dataset_prefix)  # Only the last entry as "name"
+    else:
+        # The input dataset is a raw dataset
+        args.raw_dataset_bucket_name = args.input_dataset_bucket_name
+        args.raw_dataset_prefix = args.input_dataset_prefix
+        args.raw_dataset_name = args.input_dataset_name
     # Get manifest bucket and path and 'directory' name
-    url = urlparse(args.manifest_prefix_uri)
+    url = urlparse(args.manifest_output_prefix_uri)
     args.manifest_bucket_name = url.netloc
     manifest_name = "exaspim_manifest_{}".format(args.fname_timestamp)
     # S3 "directory" path for uploading generated manifest file
     args.manifest_name = manifest_name
     args.manifest_path = url.path.strip("/") + "/" + manifest_name
+    # Alignment result upload location
+    args.alignment_dataset_name = "{}_alignment_{}".format(args.raw_dataset_name, args.fname_timestamp)
+    args.alignment_output_uri = "s3://{}/{}".format(
+        args.input_dataset_bucket_name, args.alignment_dataset_name
+    )
+    args.fusion_output_bucket = args.input_dataset_bucket_name
+    args.fusion_output_prefix = "{}_fusion_{}".format(args.raw_dataset_prefix, args.fname_timestamp)
 
 
 def capsule_main():  # pragma: no cover
     """Main entry point for trigger capsule."""
-    args = parse_args()  # To get help before the error messages
 
+    args = parse_args()  # To get help before the error messages
     cwd = os.getcwd()
     if os.path.basename(cwd) != "code":
         # We don't know where we are in the capsule environment
@@ -453,21 +587,22 @@ def capsule_main():  # pragma: no cover
         )
 
     process_args(args)
+    logger.info("This is pipeline run {}".format(args.fname_timestamp))
     metadata = get_dataset_metadata(args)
-
-    # Get code ocean creds
-    # co_cred = CodeOceanCredentials(
-    #     domain=os.environ["CODEOCEAN_DOMAIN"], token=os.environ["CUSTOM_KEY"]
-    # ).dict()
-
     # Creating the API Client
-    co_api = CodeOceanClient(domain=os.environ["CODEOCEAN_DOMAIN"], token=os.environ["CUSTOM_KEY"])
+    co_client = CodeOceanClient(domain=os.environ["CODEOCEAN_DOMAIN"], token=os.environ["CUSTOM_KEY"])
     # validate_s3_location(args, metadata)
-    raw_data_asset_id = register_raw_dataset_as_CO_data_asset(args, metadata, co_api)
+    input_data_asset_id = register_input_dataset_as_CO_data_asset(args, metadata, co_client)
+    if args.raw_data_uri:
+        register_raw_dataset_as_CO_data_asset(args, metadata, co_client)
     manifest = create_exaspim_manifest(args, metadata)
     upload_manifest(args, manifest)
-    manifest_data_asset_id = register_manifest_as_CO_data_asset(args, co_api)
+    create_and_upload_emr_config(args, metadata, manifest)
+
+    # The XML also goes into this but we need the manifest now. CO index may miss the xml
+    manifest_data_asset_id = register_manifest_as_CO_data_asset(args, co_client)
     if args.xml_capsule_id:
-        run_xml_capsule(args, co_api, raw_data_asset_id)
+        run_xml_capsule(args, co_client, input_data_asset_id, manifest_data_asset_id)
     if args.ij_capsule_id:
-        start_ij_capsule(args, co_api, raw_data_asset_id, manifest_data_asset_id)
+        start_ij_capsule(args, co_client, input_data_asset_id, manifest_data_asset_id)
+    logger.info("Done.")

--- a/src/aind_trigger_codeocean/__init__.py
+++ b/src/aind_trigger_codeocean/__init__.py
@@ -1,0 +1,2 @@
+"""Allen Institute for Neural Dynamics trigger capsule.
+"""

--- a/src/aind_trigger_codeocean/pipelines.py
+++ b/src/aind_trigger_codeocean/pipelines.py
@@ -1,0 +1,1543 @@
+"""
+Module to create pipelines in Code Ocean
+"""
+
+import logging
+import os
+import re
+import time
+from abc import ABC, abstractmethod
+from copy import deepcopy
+from datetime import datetime
+from typing import Dict, List, Optional
+
+import requests
+
+# from aind_data_schema.core.data_description import DataLevel
+from aind_data_schema.data_description import DataLevel
+from aind_codeocean_api.codeocean import CodeOceanClient
+from aind_codeocean_api.models.computations_requests import (
+    ComputationDataAsset, RunCapsuleRequest)
+from aind_codeocean_api.models.data_assets_requests import (
+    CreateDataAssetRequest, Source, Sources)
+
+
+LOG_FMT = "%(asctime)s %(message)s"
+LOG_DATE_FMT = "%Y-%m-%d %H:%M"
+
+logging.basicConfig(format=LOG_FMT, datefmt=LOG_DATE_FMT)
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+# TODO: Maybe move this to a separate library?
+class AlertBot:
+    """Class to handle sending alerts and messages in MS Teams."""
+
+    def __init__(self, url: Optional[str] = None):
+        """Initialize instance of AlertBot."""
+        self.url = url
+
+    @staticmethod
+    def _create_body_text(message: str, extra_text: Optional[str]) -> dict:
+        """
+        Parse strings into appropriate format to send to ms teams channel.
+        Check here:
+          https://learn.microsoft.com/en-us/microsoftteams/platform/
+          task-modules-and-cards/cards/cards-reference#adaptive-card
+        Parameters
+        ----------
+        message : str
+          The main message content
+        extra_text : Optional[str]
+          Additional text to send in card body
+
+        Returns
+        -------
+        dict
+
+        """
+        body: list = [
+            {"type": "TextBlock", "size": "Medium", "weight": "Bolder", "text": message}
+        ]
+        if extra_text is not None:
+            body.append({"type": "TextBlock", "text": extra_text})
+        contents = {
+            "type": "message",
+            "attachments": [
+                {
+                    "contentType": "application/vnd.microsoft.card.adaptive",
+                    "content": {
+                        "type": "AdaptiveCard",
+                        "body": body,
+                        "$schema": (
+                            "http://adaptivecards.io/schemas/adaptive-card.json"
+                        ),
+                        "version": "1.0",
+                    },
+                }
+            ],
+        }
+        return contents
+
+    def send_message(
+        self, message: str, extra_text: Optional[str] = None
+    ) -> Optional[requests.Response]:
+        """
+        Sends a message. If the url is None, the message will only be printed.
+        Otherwise, the message will be sent via requests.post
+        Parameters
+        ----------
+        message : str
+          The main message content
+        extra_text : Optional[str]
+          Additional text to send in card body
+
+        Returns
+        -------
+        Optional[requests.Response]
+          If the url is None, only print and return None. Otherwise, post
+          message to url and return the response.
+
+        """
+        if self.url is None:
+            print(message) if not extra_text else print(message, extra_text)
+            return None
+        else:
+            contents = self._create_body_text(message, extra_text)
+            response = requests.post(self.url, json=contents)
+            return response
+
+
+class CapsuleJob:
+    """This class contains convenient methods that any Capsule Job can use.
+    Any child class needs to implement the run_job method."""
+
+    def __init__(self, configs: dict, co_client: CodeOceanClient):
+        """
+        CapsuleJob class constructor.
+        Parameters
+        ----------
+        configs : dict
+          Configuration parameters of the capsule job.
+        co_client : CodeOceanClient
+          A client that can be used to interface with the Code Ocean API.
+        """
+        self.configs = configs
+        self.co_client = co_client
+
+    def wait_for_data_availability(
+        self,
+        data_asset_id: str,
+        timeout_seconds: int = 300,
+        pause_interval=10,
+    ):
+        """
+        There is a lag between when a register data request is made and when the
+        data is available to be used in a capsule.
+        Parameters
+        ----------
+        data_asset_id : str
+        timeout_seconds : int
+          Roughly how long the method should check if the data is available.
+        pause_interval : int
+          How many seconds between when the backend is queried.
+
+        Returns
+        -------
+        requests.Response
+
+        """
+        num_of_checks = 0
+        break_flag = False
+        time.sleep(pause_interval)
+        response = self.co_client.get_data_asset(data_asset_id)
+        if ((pause_interval * num_of_checks) > timeout_seconds) or (
+            response.status_code == 200
+        ):
+            break_flag = True
+        while not break_flag:
+            time.sleep(pause_interval)
+            response = self.co_client.get_data_asset(data_asset_id)
+            num_of_checks += 1
+            if ((pause_interval * num_of_checks) > timeout_seconds) or (
+                response.status_code == 200
+            ):
+                break_flag = True
+        return response
+
+    def run_capsule(
+        self,
+        capsule_id,
+        data_assets: List[ComputationDataAsset],
+        capsule_version: Optional[int] = None,
+        pause_interval: Optional[int] = None,
+        timeout_seconds: Optional[int] = None,
+    ):
+        """
+        Run a specified capsule with the given data assets. If the
+        pause_interval is set, the method will return until the capsule run is
+        finished before returning a response. If pause_interval is set, then
+        the timeout_seconds can also optionally be set to set a max wait time.
+        Parameters
+        ----------
+        capsule_id : str
+          ID of the Code Ocean capsule to be run
+        data_assets : List[Dict]
+          List of data assets for the capsule to run against. The dict should
+          have the keys id and mount.
+        capsule_version : Optional[int]
+          Run a specific version of the capsule to be run
+        pause_interval : Optional[int]
+          How often to check if the capsule run is finished.
+        timeout_seconds : Optional[int]
+          If pause_interval is set, the max wait time to check if the capsule
+          is finished.
+
+        Returns
+        -------
+
+        """
+        run_capsule_request = RunCapsuleRequest(
+            capsule_id=capsule_id, data_assets=data_assets, version=capsule_version
+        )
+        run_capsule_response = self.co_client.run_capsule(request=run_capsule_request)
+        run_capsule_response_json = run_capsule_response.json()
+        print(run_capsule_response_json)
+        computation_id = run_capsule_response_json["id"]
+
+        if pause_interval:
+            executing = True
+            num_checks = 0
+            while executing:
+                num_checks += 1
+                time.sleep(pause_interval)
+                curr_computation_state = self.co_client.get_computation(
+                    computation_id
+                ).json()
+
+                if (curr_computation_state["state"] == "completed") or (
+                    (timeout_seconds is not None)
+                    and (pause_interval * num_checks >= timeout_seconds)
+                ):
+                    executing = False
+        return run_capsule_response
+
+    def register_data(
+        self,
+        asset_name: str,
+        mount: str,
+        bucket: str,
+        prefix: str,
+        tags: List[str],
+        is_public_bucket: bool = False,
+        custom_metadata: Optional[dict] = None,
+        viewable_to_everyone=False,
+    ):
+        """
+        Register a data asset. Can also optionally update the permissions on
+        the data asset.
+        Parameters
+        ----------
+        asset_name : str
+          The name to give the data asset
+        mount : str
+          The mount folder name
+        bucket : str
+          The s3 bucket the data asset is located.
+        prefix : str
+          The s3 prefix where the data asset is located.
+        access_key_id : Optional[str]
+          The aws access key to access the bucket/prefix
+        secret_access_key : Optional[str]
+          The aws secret access key to access the bucket/prefix
+        tags : List[str]
+          The tags to use to describe the data asset
+        custom_metadata : Optional[dict]
+            What key:value metadata tags to apply to the asset.
+        viewable_to_everyone : bool
+          If set to true, then the data asset will be shared with everyone.
+          Default is false.
+
+        Returns
+        -------
+        requests.Response
+
+        """
+        source = Source(
+            aws=Sources.AWS(
+                bucket=bucket,
+                prefix=prefix,
+                keep_on_external_storage=True,
+                public=is_public_bucket,
+            )
+        )
+        request = CreateDataAssetRequest(
+            name=asset_name,
+            mount=mount,
+            source=source,
+            tags=tags,
+            custom_metadata=custom_metadata,
+        )
+        data_asset_reg_response = self.co_client.create_data_asset(request=request)
+
+        if viewable_to_everyone:
+            response_contents = data_asset_reg_response.json()
+            data_asset_id = response_contents["id"]
+            response_data_available = self.wait_for_data_availability(data_asset_id)
+
+            if response_data_available.status_code != 200:
+                raise FileNotFoundError(f"Unable to find: {data_asset_id}")
+
+            # Make data asset viewable to everyone
+            update_data_perm_response = self.co_client.update_permissions(
+                data_asset_id=data_asset_id, everyone="viewer"
+            )
+            logger.info(
+                f"Permissions response: {update_data_perm_response.status_code}"
+            )
+
+        return data_asset_reg_response
+
+    def capture_result(
+        self,
+        computation_id: str,
+        asset_name: str,
+        mount: str,
+        tags: List[str],
+        custom_metadata: Optional[dict] = None,
+        viewable_to_everyone: bool = False,
+    ):
+        """
+        Capture a result as a data asset. Can also share it with everyone.
+        Parameters
+        ----------
+        computation_id : str
+          ID of the computation
+        asset_name : str
+          Name to give the data asset
+        mount : str
+          Mount folder name for the data asset.
+        tags : List[str]
+          List of tags to describe the data asset.
+        custom_metadata : Optional[dict]
+            What key:value metadata tags to apply to the asset.
+        viewable_to_everyone : bool
+          If set to true, then the data asset will be shared with everyone.
+          Default is false.
+
+        Returns
+        -------
+        requests.Response
+
+        """
+        source = Source(computation=Sources.Computation(id=computation_id))
+        request = CreateDataAssetRequest(
+            name=asset_name,
+            mount=mount,
+            tags=tags,
+            custom_metadata=custom_metadata,
+            source=source,
+        )
+        reg_result_response = self.co_client.create_data_asset(request=request)
+        registered_results_response_json = reg_result_response.json()
+
+        # TODO: This step intermittently breaks. Adding extra check to help
+        #  figure out why.
+        if registered_results_response_json.get("id") is None:
+            raise KeyError(
+                f"Something went wrong registering {asset_name}. "
+                f"Response Status Code: {reg_result_response.status_code}. "
+                f"Response Message: {registered_results_response_json}"
+            )
+
+        results_data_asset_id = registered_results_response_json["id"]
+        response_res_available = self.wait_for_data_availability(
+            data_asset_id=results_data_asset_id
+        )
+
+        if response_res_available.status_code != 200:
+            raise FileNotFoundError(f"Unable to find: {results_data_asset_id}")
+
+        # Make captured results viewable to everyone
+        if viewable_to_everyone:
+            update_res_perm_response = self.co_client.update_permissions(
+                data_asset_id=results_data_asset_id, everyone="viewer"
+            )
+            print(f"Updating permissions {update_res_perm_response.status_code}")
+        return reg_result_response
+
+    @abstractmethod
+    def run_job(self):
+        """
+        Abstract method to run the pipeline job
+        """
+        pass
+
+
+class RegisterAindData(CapsuleJob):
+    """
+    Class to register AIND data. The data root endpoint is expected to adhere to
+    standard format.
+    """
+
+    SUBJECT_REGEX_PATTERN = re.compile(
+        r"^([^_]+)_([^_]+)_(?:\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2})(.*)"
+    )
+
+    def __init__(
+        self,
+        configs: dict,
+        co_client: CodeOceanClient,
+        viewable_to_everyone: bool = False,
+        is_public_bucket: bool = False,
+    ):
+        """
+        RegisterAindData class constructor
+        Parameters
+        ----------
+        configs : dict
+          A dictionary of configs to pass. Should contain bucket and prefix keys.
+        co_client : CodeOceanClient
+        viewable_to_everyone : bool
+          If set to true, will automatically share the data asset with everyone.
+        access_key_id : Optional[str]
+        secret_access_key : Optional[str]
+        """
+        self.viewable_to_everyone = viewable_to_everyone
+        self.is_public_bucket = is_public_bucket
+        super().__init__(configs=configs, co_client=co_client)
+
+    @property
+    def asset_name(self):
+        """Derive asset_name from prefix."""
+        return self.configs["prefix"]
+
+    @property
+    def mount(self):
+        """Derive mount from prefix."""
+        return self.configs["prefix"]
+
+    @property
+    def bucket(self):
+        """Derive bucket from configs."""
+        return self.configs["bucket"]
+
+    @property
+    def prefix(self):
+        """Derive prefix from configs."""
+        return self.configs["prefix"]
+
+    @property
+    def tags(self):
+        """Pull or derive tags from configs."""
+        if self.configs.get("tags") is not None:
+            tags = self.configs["tags"]
+        else:
+            regex_matches = re.search(self.SUBJECT_REGEX_PATTERN, self.prefix)
+            experiment_type = regex_matches.group(1)
+            subject_id = regex_matches.group(2)
+            tags = [experiment_type, DataLevel.RAW.value, subject_id]
+        return tags
+
+    @property
+    def custom_metadata(self):
+        """Pull or derive custom code ocean metadata from configs."""
+        if self.configs.get("custom_metadata") is not None:
+            return self.configs.get("custom_metadata")
+        else:
+            regex_matches = re.search(self.SUBJECT_REGEX_PATTERN, self.prefix)
+            subject_id = regex_matches.group(2)
+            return {
+                "data level": "raw data",
+                "subject id": subject_id,
+            }
+
+    def run_job(self):
+        """
+        Register the data asset on code ocean.
+        """
+        response = self.register_data(
+            asset_name=self.asset_name,
+            mount=self.mount,
+            bucket=self.bucket,
+            prefix=self.prefix,
+            is_public_bucket=self.is_public_bucket,
+            tags=self.tags,
+            custom_metadata=self.custom_metadata,
+            viewable_to_everyone=self.viewable_to_everyone,
+        )
+
+        return response
+
+
+class TestPipeline(CapsuleJob):
+    """Pipeline for testing purposes."""
+
+    def __init__(self, configs: dict, co_client: CodeOceanClient):
+        """TestPipeline class constructor."""
+        super().__init__(configs=configs, co_client=co_client)
+
+    def run_job(self) -> None:
+        """Simply print the configs to ensure they are being set."""
+        print(
+            f"Testing configs: {self.configs}. "
+            f"Testing co_client domain: {self.co_client.domain}."
+        )
+
+
+class EphysPipeline(CapsuleJob):
+    """
+    Ephys pipeline. Registers a data asset, runs the kilosort capsule, and
+    captures the result as a new data asset.
+    """
+
+    RESULT_SUFFIX = "_sorted"
+
+    def __init__(
+        self,
+        configs: dict,
+        co_client: CodeOceanClient,
+        spike_sorting_capsule_id: str,
+        spike_sorting_capsule_version: Optional[int] = None,
+        is_public_bucket: bool = False,
+        alerts_url: Optional[str] = None,
+    ):
+        """
+        EphysPipeline class constructor
+        Parameters
+        ----------
+        configs : dict
+          Needs to contain bucket and prefix.
+        co_client : CodeOceanClient
+        spike_sorting_capsule_id : str
+        spike_sorting_capsule_version: Optional[int]
+        access_key_id : Optional[str]
+        secret_access_key : Optional[str]
+        alerts_url : Optional[str]
+          Optional url to send notifications about job process.
+        """
+        self.is_public_bucket = is_public_bucket
+        self.spike_sorting_capsule_id = spike_sorting_capsule_id
+        self.spike_sorting_capsule_version = spike_sorting_capsule_version
+        self.alerts_url = alerts_url
+        super().__init__(configs=configs, co_client=co_client)
+
+    def _create_suffix(self, dt: datetime) -> str:
+        """Create the suffix for the spike sorted results folder"""
+        return self.RESULT_SUFFIX + "_" + dt.strftime("%Y-%m-%d_%H-%M-%S")
+
+    def run_job(self):
+        """
+        Runs the Ephys pipeline
+        """
+
+        alert_bot = AlertBot(url=self.alerts_url)
+
+        try:
+            alert_bot.send_message(f"Starting {self.configs.get('prefix')}")
+            # Register the data asset
+            register_job = RegisterAindData(
+                configs=self.configs,
+                co_client=self.co_client,
+                viewable_to_everyone=True,
+                is_public_bucket=self.is_public_bucket,
+            )
+            # Set default code ocean metadata tags if they don't exist
+            if register_job.configs.get("custom_metadata") is None:
+                regex_matches = re.search(
+                    register_job.SUBJECT_REGEX_PATTERN, register_job.prefix
+                )
+                subject_id = regex_matches.group(2)
+                register_job.configs["custom_metadata"] = {
+                    "modality": "Extracellular electrophysiology",
+                    "experiment type": "ecephys",
+                    "data level": "raw data",
+                    "subject id": subject_id,
+                }
+
+            data_asset_reg_response = register_job.run_job()
+            data_asset_id = data_asset_reg_response.json()["id"]
+
+            # Run Spike sorting pipeline
+            mount = register_job.mount
+            data_assets = [ComputationDataAsset(id=data_asset_id, mount=mount)]
+            # Run capsule and check every 3 minutes if it's finished.
+            # No timeout set.
+            run_capsule_response = self.run_capsule(
+                capsule_id=self.spike_sorting_capsule_id,
+                capsule_version=self.spike_sorting_capsule_version,
+                data_assets=data_assets,
+                timeout_seconds=None,
+                pause_interval=180,
+            )
+
+            # Capture result as a data asset
+            spike_sorted_suffix = self._create_suffix(dt=datetime.utcnow())
+            new_asset_name = register_job.prefix + spike_sorted_suffix
+            # This copies the tags from the input data asset and replaces
+            # the raw tag with the derived tag
+            res_tags = [
+                DataLevel.DERIVED.value if x == DataLevel.RAW.value else x
+                for x in register_job.tags
+            ]
+            results_metadata = deepcopy(register_job.custom_metadata)
+            results_metadata["data level"] = "derived data"
+            capture_result_response = self.capture_result(
+                computation_id=run_capsule_response.json()["id"],
+                asset_name=new_asset_name,
+                mount=new_asset_name,
+                tags=res_tags,
+                custom_metadata=results_metadata,
+                viewable_to_everyone=True,
+            )
+            alert_bot.send_message(message=f"Finished {self.configs.get('prefix')}")
+        except Exception as e:
+            alert_bot.send_message(
+                message=f"Error with {self.configs.get('prefix')}", extra_text=str(e)
+            )
+            raise e
+
+        return capture_result_response
+
+
+class GenericPipeline(CapsuleJob):
+    """
+    Generic pipeline. Registers a data asset (optional), runs a capsule, and
+    captures the result as a new data asset.
+    """
+
+    def __init__(
+        self,
+        configs: dict,
+        co_client: CodeOceanClient,
+        capsule_id: str,
+        results_suffix: str = "processed",
+        existing_asset_id: Optional[str] = None,
+        capsule_version: Optional[int] = None,
+        is_public_bucket: bool = False,
+        alerts_url: Optional[str] = None,
+    ):
+        """
+        GenericPipeline class constructor. Can be used to optionally register
+        a new data asset and run a capsule on the data asset. If the data
+        asset has already been registered, then the registration can be skipped
+        by setting existing_asset_id to the data asset id. The naming
+        convention is expected to be followed.
+        Parameters
+        ----------
+        configs : dict
+          Needs to contain bucket and prefix.
+        co_client : CodeOceanClient
+        capsule_id : str
+          The id of the capsule to run
+        results_suffix : str
+          Append this to the output files. Default is processed. So the results
+          data asset might look like:
+          Other_12345_2020-10-10_10-10-10_processed_2020-11-10-10_10-10-10
+        existing_asset_id : Optional[str]
+          If the data asset has already been registered to code ocean, set this
+          to the data asset id to skip creating another data asset.
+        capsule_version: Optional[int]
+        access_key_id : Optional[str]
+        secret_access_key : Optional[str]
+        alerts_url : Optional[str]
+          Optional url to send notifications about job process.
+        """
+        self.is_public_bucket = is_public_bucket
+        self.capsule_id = capsule_id
+        self.results_suffix = results_suffix
+        self.existing_asset_id = existing_asset_id
+        self.capsule_version = capsule_version
+        self.alerts_url = alerts_url
+        super().__init__(configs=configs, co_client=co_client)
+
+    def _create_suffix(self, dt: datetime) -> str:
+        """Create the suffix for the results folder"""
+        return self.results_suffix + "_" + dt.strftime("%Y-%m-%d_%H-%M-%S")
+
+    def run_job(self):
+        """
+        Runs the Generic pipeline
+        """
+
+        alert_bot = AlertBot(url=self.alerts_url)
+
+        try:
+            alert_bot.send_message(f"Starting {self.configs.get('prefix')}")
+            # Register the data asset
+            register_job = RegisterAindData(
+                configs=self.configs,
+                co_client=self.co_client,
+                viewable_to_everyone=True,
+                is_public_bucket=self.is_public_bucket,
+            )
+            # Set default code ocean metadata tags if they don't exist
+            if register_job.configs.get("custom_metadata") is None:
+                regex_matches = re.search(
+                    register_job.SUBJECT_REGEX_PATTERN, register_job.prefix
+                )
+                subject_id = regex_matches.group(2)
+                register_job.configs["custom_metadata"] = {
+                    "data level": "raw data",
+                    "subject id": subject_id,
+                }
+
+            if self.existing_asset_id is None:
+                data_asset_reg_response = register_job.run_job()
+                data_asset_id = data_asset_reg_response.json()["id"]
+            else:
+                data_asset_id = self.existing_asset_id
+
+            # Run capsule
+            mount = register_job.mount
+            # data_assets = [{"id": data_asset_id, "mount": mount}]
+            data_assets = [ComputationDataAsset(id=data_asset_id, mount=mount)]
+            # Run capsule and check every 2 minutes if it's finished.
+            # No timeout set.
+            run_capsule_response = self.run_capsule(
+                capsule_id=self.capsule_id,
+                capsule_version=self.capsule_version,
+                data_assets=data_assets,
+                timeout_seconds=None,
+                pause_interval=120,
+            )
+
+            # Capture result as a data asset
+            results_suffix = self._create_suffix(dt=datetime.utcnow())
+            new_asset_name = register_job.prefix + "_" + results_suffix
+            res_tags = [
+                DataLevel.DERIVED.value if x == DataLevel.RAW.value else x
+                for x in register_job.tags
+            ]
+            results_metadata = deepcopy(register_job.custom_metadata)
+            results_metadata["data level"] = "derived data"
+            capture_result_response = self.capture_result(
+                computation_id=run_capsule_response.json()["id"],
+                asset_name=new_asset_name,
+                mount=new_asset_name,
+                tags=res_tags,
+                custom_metadata=results_metadata,
+                viewable_to_everyone=True,
+            )
+            alert_bot.send_message(message=f"Finished {self.configs.get('prefix')}")
+        except Exception as e:
+            alert_bot.send_message(
+                message=f"Error with {self.configs.get('prefix')}", extra_text=str(e)
+            )
+            raise e
+
+        return capture_result_response
+
+
+class Pipeline(ABC):
+    """
+    Abstract class to create pipelines
+    """
+
+    def __init__(self, configs: dict, sleep_time: int = 600):
+        """
+        Constructor to create a pipeline.
+
+        Parameters
+        ----------------
+
+        configs: dict
+            Dictionary with the pipeline configuration
+
+        sleep_time: int
+            Wait time to check the status of the capsule
+            computation in seconds
+
+        """
+        self.__configs = configs
+        self.__sleep_time = sleep_time
+        super().__init__()
+
+    @property
+    def configs(self) -> dict:
+        """
+        Getter of the config parameter
+
+        Returns
+        ----------------
+        dict
+            Dictionary with the pipeline configuration
+        """
+        return self.__configs
+
+    @configs.setter
+    def configs(self, new_config: dict) -> None:
+        """
+        Setter of the config parameter
+
+        Parameters
+        ----------------
+        new_config: dict
+            Dictionary with the pipeline configuration
+        """
+        self.__configs = new_config
+
+    @property
+    def sleep_time(self) -> int:
+        """
+        Getter of the sleep_time parameter
+
+        Returns
+        ----------------
+        int
+            Integer with the sleep time in seconds
+        """
+        return self.__sleep_time
+
+    @sleep_time.setter
+    def sleep_time(self, new_sleep_time: int) -> None:
+        """
+        Setter of the sleep_time parameter
+
+        Parameters
+        ----------------
+        new_sleep_time: int
+            Integer with the sleep time in seconds
+        """
+        self.__sleep_time = new_sleep_time
+
+    @abstractmethod
+    def run_job(self):
+        """
+        Abstract method to run the pipeline job
+        """
+        pass
+
+    def wait_for_capsule_to_finish(
+        self, co_client: CodeOceanClient, computation_id: str
+    ) -> dict:
+        """
+        Waits for a capsule to finish
+
+        Parameters
+        ----------------
+        co_client: CodeOceanClient
+            Code Ocean client to make calls to the API
+
+        computation_id: str
+            Computation id used to check the current
+            computation status
+
+        Returns
+        ----------------
+        dict
+            Dictionary with the computation status
+        """
+
+        executing = True
+
+        while executing:
+
+            time.sleep(self.sleep_time)
+
+            curr_computation_state = co_client.get_computation(computation_id).json()
+
+            if curr_computation_state["state"] == "completed":
+                executing = False
+
+        return curr_computation_state
+
+    def wait_for_data_availability(
+        self,
+        co_client: CodeOceanClient,
+        data_asset_id: str,
+        timeout_seconds: int = 300,
+        pause_interval=10,
+    ):
+        """
+        There is a lag between when a register data request is made and when the
+        data is available to be used in a capsule.
+        Parameters
+        ----------
+        co_client: CodeOceanClient
+            Code ocean client
+        data_asset_id : str
+        timeout_seconds : int
+          Roughly how long the method should check if the data is available.
+        pause_interval : int
+          How many seconds between when the backend is queried.
+
+        Returns
+        -------
+        requests.Response
+
+        """
+        num_of_checks = 0
+        break_flag = False
+        time.sleep(pause_interval)
+        response = co_client.get_data_asset(data_asset_id)
+        if ((pause_interval * num_of_checks) > timeout_seconds) or (
+            response.status_code == 200
+        ):
+            break_flag = True
+        while not break_flag:
+            time.sleep(pause_interval)
+            response = co_client.get_data_asset(data_asset_id)
+            num_of_checks += 1
+            if ((pause_interval * num_of_checks) > timeout_seconds) or (
+                response.status_code == 200
+            ):
+                break_flag = True
+        return response
+
+    def make_data_viewable(self, co_client: CodeOceanClient, response_contents: dict):
+        """
+        Makes a registered dataset viewable
+
+        Parameters
+        ----------
+        co_client: CodeOceanClient
+            Code ocean client
+
+        response_contents: dict
+            Dictionary with the response
+            of the created data asset
+
+        """
+        data_asset_id = response_contents["id"]
+        response_data_available = self.wait_for_data_availability(
+            co_client, data_asset_id
+        )
+
+        if response_data_available.status_code != 200:
+            raise FileNotFoundError(f"Unable to find: {data_asset_id}")
+
+        # Make data asset viewable to everyone
+        update_data_perm_response = co_client.update_permissions(
+            data_asset_id=data_asset_id, everyone="viewer"
+        )
+        logger.info(f"Data asset viewable to everyone: {update_data_perm_response}")
+
+
+class SmartspimPipeline(Pipeline):
+    """
+    SmartSPIM pipeline
+    """
+
+    def __init__(
+        self,
+        configs: dict,
+        stitching_co_id: str,
+        ccf_registration_co_id: str,
+        cell_segmentation_co_id: str,
+        cell_quantification_co_id: str,
+        sleep_time=600,
+    ):
+        """
+        Constructor of the smartSPIM pipeline
+
+        Parameters
+        ----------------
+        configs: dict
+            Dictionary with the pipeline configuration
+
+        sleep_time: int
+            Wait time to check the status of the capsule
+            computation in seconds
+
+        """
+        super().__init__(configs, sleep_time)
+        self.stitching_co_id = stitching_co_id
+        self.ccf_registration_co_id = ccf_registration_co_id
+        self.cell_segmentation_co_id = cell_segmentation_co_id
+        self.cell_quantification_co_id = cell_quantification_co_id
+
+    def _get_path_from_result_file(
+        self,
+        co_client: CodeOceanClient,
+        computation_id: str,
+        path_to_file: str,
+    ) -> str:
+        """
+        Gets the path of a smartSPIM pipeline result
+
+        Parameters
+        ----------------
+
+        co_client: CodeOceanClient
+            Code Ocean Client to call the API
+
+        computation_id: str
+            Computation id of a computation in a
+            capsule
+
+        path_to_file: str
+            Path to the file that has the output path
+            of a result stored in a different bucket
+
+        Returns
+        ----------------
+        str
+            String with the path
+        """
+
+        res = co_client.get_result_file_download_url(computation_id, path_to_file)
+        res = res.json()
+
+        s3_path = None
+
+        if "url" in res:
+            response = requests.get(res["url"])
+            txt_content = response.content.decode("utf-8")
+            s3_path = txt_content.split(" ")[-1]
+
+        return s3_path
+
+    def __register_data_asset_external_bucket(
+        self,
+        co_client: CodeOceanClient,
+        computation_state: dict,
+        output_processed_filename: str,
+        tags: list,
+    ) -> dict:
+        """
+        Registers a data asset stored in a bucket
+
+        Parameters
+        ----------------
+
+        co_client: CodeOceanClient
+            Code Ocean Client to call the API
+
+        computation_state: dict
+            Dictionary with the data related to
+            a computation
+
+        output_processed_filename: str
+            Filename with the output path of the dataset
+
+        tags: list
+            Tags that will be added to the data asset
+
+        Returns
+        ----------------
+        dict
+            Result of the Code Ocean API call to
+            create a new data asset
+        """
+
+        result_created_data_asset_res = None
+
+        s3_path = self._get_path_from_result_file(
+            co_client, computation_state["id"], output_processed_filename
+        )
+
+        if s3_path:
+            s3_path_splitted = [val for val in s3_path.rstrip().split("/") if len(val)]
+
+            asset_name = s3_path_splitted[-1]
+            bucket_name = s3_path_splitted[1]
+            prefix = "/".join(s3_path_splitted[2:-1] + [s3_path_splitted[-1]])
+
+            # Registering data asset from the computation
+            # I'm assuming this is trying to register an asset in a public
+            # bucket.
+
+            source = Source(
+                aws=Sources.AWS(
+                    bucket=bucket_name,
+                    prefix=prefix,
+                    keep_on_external_storage=True,
+                    public=True,
+                )
+            )
+            create_data_asset_request = CreateDataAssetRequest(
+                name=asset_name, tags=tags, mount=asset_name, source=source
+            )
+
+            # Registering data asset from the computation
+            result_created_data_asset_res = co_client.create_data_asset(
+                request=create_data_asset_request
+            )
+            result_created_data_asset_res = result_created_data_asset_res.json()
+
+            logger.info(
+                f"Registered result as data asset: {result_created_data_asset_res}"
+            )
+        else:
+            logger.error(
+                f"An error ocurred while reading the content file {output_processed_filename}!"
+            )
+
+        return result_created_data_asset_res
+
+    def trigger_stitching_capsule(
+        self,
+        co_client: CodeOceanClient,
+        params: dict,
+        viewable_to_everyone: Optional[bool] = True,
+    ) -> dict:
+        """
+        Triggers the stitching capsule
+
+        Parameters
+        ----------------
+        co_client: CodeOceanClient
+            Code Ocean Client to call the API
+
+        params: dict
+            Dictionary with the pipeline
+            parameters
+
+        viewable_to_everyone: Optional[bool]
+            Make registered dataset available
+            to everyone. Default: True
+
+        Returns
+        ----------------
+        Data asset with the stitching results
+
+        """
+        tags = ["smartspim", DataLevel.RAW.value]
+        bucket = self.configs["bucket"]
+        prefix = self.configs["prefix"]
+        mount = prefix
+        # aws_key = os.getenv('AWS_ACCESS_KEY_ID')
+        # aws_secret = os.getenv('AWS_SECRET_ACCESS_KEY')
+
+        # Since the access keys above are commented out, I'm assuming this
+        # is trying to create a data asset from a public bucket
+        # Creating data asset
+        source = Source(
+            aws=Sources.AWS(
+                bucket=bucket,
+                prefix=prefix,
+                keep_on_external_storage=True,
+                public=True,
+            )
+        )
+        create_data_asset_request = CreateDataAssetRequest(
+            name=prefix, mount=mount, source=source, tags=tags
+        )
+        data_asset_reg_response = co_client.create_data_asset(
+            request=create_data_asset_request
+        )
+        response_contents = data_asset_reg_response.json()
+        logger.info(f"Created data asset in Code Ocean: {response_contents}")
+
+        if viewable_to_everyone:
+            self.make_data_viewable(co_client, response_contents)
+
+        data_asset_id = response_contents["id"]
+        data_assets = [ComputationDataAsset(id=data_asset_id, mount=mount)]
+
+        # Creating run
+        run_capsule_request = RunCapsuleRequest(
+            capsule_id=self.stitching_co_id,
+            data_assets=data_assets,
+            parameters=[
+                f"/data/{prefix}/SmartSPIM",  # Input data
+                f"/{params['co_folder']}/{prefix}",  # preprocessed data
+                f"/{params['co_folder']}/{prefix}",  # output data
+                str(params["channel"]),  # stitch channel
+                str(params["resolution"]["x"]),  # Resolution in X
+                str(params["resolution"]["y"]),  # Resolution in Y
+                str(params["resolution"]["z"]),  # Resolution in Z
+                str(16),  # CPUs
+                bucket,  # Bucket
+            ],
+        )
+        run_capsule_response = co_client.run_capsule(request=run_capsule_request)
+        run_capsule_response_json = run_capsule_response.json()
+        logger.info(
+            f"Created run [stitching] in Code Ocean: {run_capsule_response_json}"
+        )
+
+        # Saving result as data asset once capsule finishes running
+        computation_state = self.wait_for_capsule_to_finish(
+            co_client=co_client, computation_id=run_capsule_response_json["id"]
+        )
+
+        # Since the datasets are being saved somewhere else, we need to create them in CO as data assets
+        output_processed_filename = "output_stitching.txt"
+        result_created_data_asset_res = self.__register_data_asset_external_bucket(
+            co_client,
+            computation_state,
+            output_processed_filename,
+            ["smartspim", "processed"],
+        )
+
+        # Making stitched data viewable to everyone
+        if viewable_to_everyone:
+            self.make_data_viewable(co_client, result_created_data_asset_res)
+
+        return result_created_data_asset_res
+
+    def trigger_ccf_registration(
+        self,
+        co_client: CodeOceanClient,
+        smartspim_stitched_data_asset: dict,
+        img_channel: str,
+        img_scale: str = "3",
+        input_zarr_directory: str = "processed/stitching/OMEZarr",
+    ) -> dict:
+        """
+        Triggers the ccf registration capsule
+
+        Parameters
+        ----------------
+        co_client: CodeOceanClient
+            Code Ocean Client to call the API
+
+        smartspim_stitched_data_asset: dict
+            Dictionary with the stitched data asset
+            information
+
+        img_channel: str
+            Channel for CCF registration
+
+        img_scale: str
+            Multiscale used for the CCF registration
+
+        input_zarr_directory: str
+            Directory where the image is stored
+
+        Returns
+        ----------------
+        dict
+            Dictionary with the capsule execution
+            details
+        """
+
+        run_ccf_capsule_response = None
+
+        if smartspim_stitched_data_asset:
+            logger.info(
+                f"Executing CCF registration with data asset {smartspim_stitched_data_asset}"
+            )
+
+            data_assets_ccf = [
+                ComputationDataAsset(
+                    id=smartspim_stitched_data_asset["id"],
+                    mount=smartspim_stitched_data_asset["name"],
+                )
+            ]
+
+            run_capsule_request = RunCapsuleRequest(
+                capsule_id=self.ccf_registration_co_id,
+                data_assets=data_assets_ccf,
+                parameters=[
+                    smartspim_stitched_data_asset["name"],
+                    img_channel,
+                    img_scale,
+                    input_zarr_directory,
+                ],
+            )
+            run_ccf_capsule_response = co_client.run_capsule(
+                request=run_capsule_request
+            )
+
+            run_ccf_capsule_response = run_ccf_capsule_response.json()
+
+            logger.info(
+                f"Created run [ccf registration] in Code Ocean: {run_ccf_capsule_response}"
+            )
+
+            if "id" in run_ccf_capsule_response:
+                # Saving result as data asset once capsule finishes running
+
+                # flake8: noqa: F841
+                computation_state = self.wait_for_capsule_to_finish(
+                    co_client=co_client,
+                    computation_id=run_ccf_capsule_response["id"],
+                )
+
+                # Saving CCF result as data asset ?? If so, fix asset name for registration
+                # output_processed_filename = 'output_ccf.txt'
+
+                # result_created_data_asset_res = self.__register_data_asset_external_bucket(
+                #     co_client,
+                #     computation_state,
+                #     output_processed_filename,
+                #     ['smartspim', 'processed', 'ccf']
+                # )
+
+            else:
+                logger.error(
+                    f"Error while triggering capsule: {run_ccf_capsule_response}"
+                )
+
+        else:
+            logger.error(
+                f"An error occurred while trigerring CCF Registration. Check data asset: {smartspim_stitched_data_asset}"
+            )
+
+        return run_ccf_capsule_response
+
+    def trigger_cell_segmentation(
+        self,
+        co_client: CodeOceanClient,
+        smartspim_stitched_data_asset: dict,
+        img_channel: str,
+        img_scale: str = "0",
+        chunk_size: str = "500",
+    ) -> dict:
+        """
+        Triggers the cell segmentation capsule
+
+        Parameters
+        ----------------
+        co_client: CodeOceanClient
+            Code Ocean Client to call the API
+
+        smartspim_stitched_data_asset: dict
+            Dictionary with the stitched data asset
+            information
+
+        img_channel: str
+            Channel for CCF registration
+
+        img_scale: str
+            Multiscale used for the CCF registration
+
+        Returns
+        ----------------
+        dict
+            Dictionary with the capsule execution
+            details
+        """
+
+        run_seg_capsule_response = None
+
+        if smartspim_stitched_data_asset:
+            logger.info(
+                f"Executing cell segmentation with data asset {smartspim_stitched_data_asset}"
+            )
+
+            data_assets_seg = [
+                ComputationDataAsset(
+                    id=smartspim_stitched_data_asset["id"],
+                    mount=smartspim_stitched_data_asset["name"],
+                )
+            ]
+
+            run_capsule_request = RunCapsuleRequest(
+                capsule_id=self.cell_segmentation_co_id,
+                data_assets=data_assets_seg,
+                parameters=[
+                    smartspim_stitched_data_asset["name"],
+                    img_channel,
+                    img_scale,
+                    chunk_size,
+                    0,  # start signal
+                    -1,  # end signal
+                    self.configs["bucket"],
+                ],
+            )
+            run_seg_capsule_response = co_client.run_capsule(
+                request=run_capsule_request
+            )
+
+            run_seg_capsule_response = run_seg_capsule_response.json()
+
+            logger.info(
+                f"Created run [ccf registration] in Code Ocean: {run_seg_capsule_response}"
+            )
+
+            if "id" in run_seg_capsule_response:
+                # Saving result as data asset once capsule finishes running
+                computation_state = self.wait_for_capsule_to_finish(
+                    co_client=co_client,
+                    computation_id=run_seg_capsule_response["id"],
+                )
+
+            else:
+                logger.error(
+                    f"Error while triggering capsule: {run_seg_capsule_response}"
+                )
+
+        else:
+            logger.error(
+                f"An error occurred while trigerring cell segmentation. Check data asset: {smartspim_stitched_data_asset}"
+            )
+
+        return run_seg_capsule_response
+
+    def trigger_cell_quantification(
+        self,
+        co_client: CodeOceanClient,
+        smartspim_stitched_data_asset: dict,
+        channel_name: str,
+        save_path: str,
+        intermediate_folder: str = "processed/stitching/OMEZarr",
+        downsample_res: str = "3",
+        reference_microns_ccf: str = "25",
+    ):
+        """
+        Triggers the quantification capsule
+
+        Parameters
+        ----------------
+        co_client: CodeOceanClient
+            Code Ocean Client to call the API
+
+        smartspim_stitched_data_asset: dict
+            Dictionary with the stitched data asset
+            information
+
+        channel_name: str
+            Channel for cell quantification. CCF registration
+            and cell segmentation steps must have been executed
+            before
+
+        save_path: str
+            Path where the capsule with write its outputs
+
+        intermediate_folder: str
+            Intermediate folder where the results are
+            for the smartspim datasets. It's important since
+            we have multiple versions of the pipeline.
+            Default: "processed/stitching/OMEZarr"
+
+        downsample_res: str
+            Resolution that was used in the
+            CCF registration
+
+        reference_microns_ccf: str
+            Reference size in microns for the CCF
+            Atlas
+        Returns
+        ----------------
+        dict
+            Dictionary with the capsule execution
+            details
+        """
+
+        run_cell_quant_capsule_response = None
+
+        if smartspim_stitched_data_asset:
+            logger.info(
+                f"Executing quantification with data asset {smartspim_stitched_data_asset}"
+            )
+
+            data_assets_ccf = [
+                {
+                    "id": smartspim_stitched_data_asset["id"],
+                    "mount": smartspim_stitched_data_asset["name"],
+                }
+            ]
+            data_assets_ccf = [
+                ComputationDataAsset(
+                    id=smartspim_stitched_data_asset["id"],
+                    mount=smartspim_stitched_data_asset["name"],
+                )
+            ]
+            run_capsule_request = RunCapsuleRequest(
+                capsule_id=self.cell_quantification_co_id,
+                data_assets=data_assets_ccf,
+                parameters=[
+                    smartspim_stitched_data_asset,
+                    channel_name,
+                    save_path,
+                    intermediate_folder,
+                    downsample_res,
+                    reference_microns_ccf,
+                ],
+            )
+            run_cell_quant_capsule_response = co_client.run_capsule(
+                request=run_capsule_request
+            )
+
+            run_cell_quant_capsule_response = run_cell_quant_capsule_response.json()
+
+            logger.info(
+                f"Created run [cell quantification] in Code Ocean: {run_cell_quant_capsule_response}"
+            )
+
+            if "id" in run_cell_quant_capsule_response:
+                # Saving result as data asset once capsule finishes running
+
+                # flake8: noqa: F841
+                computation_state = self.wait_for_capsule_to_finish(
+                    co_client=co_client,
+                    computation_id=run_cell_quant_capsule_response["id"],
+                )
+
+            else:
+                logger.error(
+                    f"Error while triggering capsule: {run_cell_quant_capsule_response}"
+                )
+
+        else:
+            logger.error(
+                f"An error occurred while trigerring CCF Registration. Check data asset: {smartspim_stitched_data_asset}"
+            )
+
+        return run_cell_quant_capsule_response
+
+    def run_job(self):
+        """
+        Executes the SmartSPIM pipeline
+        """
+        codeocean_domain = os.getenv("CODEOCEAN_DOMAIN")
+        co_client = CodeOceanClient(
+            domain=codeocean_domain, token=os.getenv("CUSTOM_KEY")
+        )
+
+        if "stitching" not in self.configs:
+            logger.info("Pipeline can't be triggered without stitching")
+            exit(1)
+
+        # Trigger stitching
+        result_created_data_asset_res = self.trigger_stitching_capsule(
+            co_client, self.configs["stitching"]
+        )
+
+        # flake8: noqa: F841
+        if (
+            "registration" in self.configs
+            and "channels" in self.configs["registration"]
+        ):
+            for channel_name in self.configs["registration"]["channels"]:
+                logger.info(f"Registering channel {channel_name}")
+
+                result_data_asset_registration = self.trigger_ccf_registration(
+                    co_client,
+                    result_created_data_asset_res,
+                    channel_name,
+                    self.configs["registration"]["input_scale"],
+                    "processed/stitching/OMEZarr",
+                )
+
+        # Trigger Cell Segmentation
+        if (
+            "segmentation" in self.configs
+            and "channels" in self.configs["segmentation"]
+        ):
+            for channel_name in self.configs["registration"]["channels"]:
+                logger.info(f"Cell segmentation in channel {channel_name}")
+
+                result_cell_segmentation = self.trigger_cell_segmentation(
+                    co_client,
+                    result_created_data_asset_res,
+                    channel_name,
+                    self.configs["segmentation"]["input_scale"],
+                    self.configs["segmentation"]["chunksize"],
+                )
+
+        if "registration" in self.configs and "segmentation" in self.configs:
+            # Executing only when registration and segmentation are executed
+            channels_ccf = set(self.configs["registration"]["channels"])
+            channels_cell = set(self.configs["registration"]["channels"])
+
+            # Getting channels that are common for the two configurations
+            common_channels = channels_ccf & channels_cell
+
+            for channel_name in common_channels:
+                logger.info(f"Running quantification in channel {channel_name}")
+
+                result_cell_quantification = self.trigger_cell_quantification(
+                    co_client=co_client,  # Code ocean client
+                    smartspim_stitched_data_asset=result_created_data_asset_res,  # Stitched dataset
+                    channel_name=channel_name,  # Channel name
+                    save_path="/results/",  # output folder
+                    intermediate_folder="processed/stitching/OMEZarr",
+                    downsample_res="3",
+                    reference_microns_ccf="25",
+                )

--- a/tests/test_capsule.py
+++ b/tests/test_capsule.py
@@ -1,0 +1,15 @@
+"""Tests for trigger capsule functions"""
+import unittest
+from datetime import datetime
+
+import aind_exaspim_pipeline_utils.trigger.capsule
+
+
+class TestCapsule(unittest.TestCase):
+    """Capsule tests"""
+
+    def test_get_fname_timestamp(self):
+        """Test get_fname_timestamp"""
+        timestamp = aind_exaspim_pipeline_utils.trigger.capsule.get_fname_timestamp(
+            datetime(2020, 1, 1, 1, 2, 3))
+        self.assertEqual(timestamp, "2020-01-01_01-02-03")


### PR DESCRIPTION
  * Copy ``aind-trigger-codeocean`` code from @jtyoung84  temporarily here. This can be removed once it can be installed without any modification.
  * Replace old codeocean api calls with ``CapsuleJob`` methods from aind-trigger-codeocean.
  * Fix ``RegisterDataJob`` call signature.
  * Minor fixes in test runs.
  * Updates relating raw and input data assets handling. Support the processing of both flat-fielded or raw datasets.
  * Update timestamps for local time zone.
  * Replace prints with logger calls.
  * Add emr ready xml writing. Make result xml always the same name.
  * Add emr config and qc output generation.
  * Add determination of subject id from metadata files and/or from file name. Check for consistency if both are present.
  * Add ng link generation to imagej_wrapper code.
  * Stick with aind-codeocean-api==v0.3.0 Currently aind-codeocean-api and aind-data-transfer have conflicting pydantic and aind-data-schema dependencies.
  * Fix emr_xml writeout encoding for `micro` symbol.
  * Update log messages.