### PR TITLE
Staged execution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ readme = "README.md"
 dynamic = ["version"]
 
 dependencies = [
+    'click',
     'argschema',
     's3fs',
     'pydantic',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,6 @@ classifiers = [
 readme = "README.md"
 dynamic = ["version"]
 
-[tool.hatch.metadata]
-allow-direct-references=true
-
 dependencies = [
     'click',
     'argschema',
@@ -30,7 +27,7 @@ dependencies = [
     'aind-data-schema==0.38.0',
     'aind-codeocean-api==0.5.0',
     'aind-ng-link>=1.0.15',
-    'matchviz@git+http://www.github.com/d-v-b/matchviz@points_vs_matches'
+    'matchviz==0.0.6'
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,9 @@ dependencies = [
     'aind-data-schema==0.38.0',
     'aind-codeocean-api==0.5.0',
     'aind-ng-link>=1.0.15',
-    'matchviz==0.0.6'
+    'matchviz==0.0.6',
+    'python-dotenv',
+    'numpy<2'
 ]
 
 [project.optional-dependencies]
@@ -39,7 +41,7 @@ dev = [
     'interrogate',
     'isort',
     'Sphinx',
-    'furo'
+    'furo',
 ]
 
 n5tozarr = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,9 @@ classifiers = [
 readme = "README.md"
 dynamic = ["version"]
 
+[tool.hatch.metadata]
+allow-direct-references=true
+
 dependencies = [
     'click',
     'argschema',
@@ -24,9 +27,10 @@ dependencies = [
     'psutil',
     'matplotlib',
     'scipy',
-    'aind-data-schema',
-    'aind-codeocean-api==0.3.0',
+    'aind-data-schema==0.38.0',
+    'aind-codeocean-api==0.5.0',
     'aind-ng-link>=1.0.15',
+    'matchviz@git+http://www.github.com/d-v-b/matchviz@points_vs_matches'
 ]
 
 [project.optional-dependencies]

--- a/src/aind_exaspim_pipeline_utils/exaspim_manifest.py
+++ b/src/aind_exaspim_pipeline_utils/exaspim_manifest.py
@@ -6,13 +6,17 @@ import os
 from datetime import datetime
 from typing import Optional, Tuple, List, Union
 
-from aind_data_schema import DataProcess
+from aind_data_schema.core.processing import DataProcess
 from aind_data_schema.base import AindModel
-from pydantic import Field, validator
+from pydantic.v1 import Field, validator
 import argparse
 
 from .imagej_macros import ImagejMacros
-
+import dotenv
+dotenv.load_dotenv()
+DEFAULT_OUTPUT_DIR = "../results/"
+OUTPUT_DIR = os.environ.get('OUTPUT_DIR', DEFAULT_OUTPUT_DIR)
+DEFAULT_MANIFEST_NAME = "../data/manifest/exaspim_manifest.json"
 
 # Based on aind-data-transfer/scripts/processing_manifest.py
 
@@ -495,7 +499,7 @@ def get_capsule_manifest(
     if args is not None:
         manifest_name = args.manifest_name
     else:
-        manifest_name = "../data/manifest/exaspim_manifest.json"
+        manifest_name = os.environ.get('MANIFEST_NAME', DEFAULT_MANIFEST_NAME)
     with open(manifest_name, "r") as f:
         json_data = json.load(f)
     return ExaspimProcessingPipeline(**json_data)
@@ -529,21 +533,21 @@ def get_capsule_metadata() -> dict:  # pragma: no cover
 
 def write_result_dataset_metadata(dataset_metadata: dict) -> None:  # pragma: no cover
     """Write the updated metadata file to the Code Ocean results folder."""
-    os.makedirs("../results/meta", exist_ok=True)
-    with open("../results/meta/metadata.json", "w") as f:
+    os.makedirs(os.path.join(OUTPUT_DIR, "meta"), exist_ok=True)
+    with open(os.path.join(OUTPUT_DIR, "meta/metadata.json"), "w") as f:
         json.dump(dataset_metadata, f, indent=3)
 
 
 def write_process_metadata(capsule_metadata: DataProcess, prefix=None) -> None:  # pragma: no cover
     """Write the process.json file about this processing step to the Code Ocean results folder."""
-    # os.makedirs("../results/meta", exist_ok=True)
+
     if prefix is None:
         prefix = ""
     else:
         prefix = prefix + "_"
-    # with open(f"../results/meta/exaspim_{prefix}process.json", "w") as f:
-    with open("../results/process_output.json", "w") as f:
-        f.write(capsule_metadata.json(indent=3))
+    
+    with open(os.path.join(OUTPUT_DIR, "process_output.json"), "w") as f:
+        f.write(capsule_metadata.model_dump_json(indent=3))
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/aind_exaspim_pipeline_utils/imagej_wrapper.py
+++ b/src/aind_exaspim_pipeline_utils/imagej_wrapper.py
@@ -581,8 +581,8 @@ def imagej_do_registrations(pipeline_manifest: ExaspimProcessingPipeline,
 import click
 
 @click.command
-@click.option('--do_detection', type=click.BOOL, default=True)
-@click.option('--do_registrations', type=click.BOOL, default=True)
+@click.option('--detection', type=click.BOOL, default=True)
+@click.option('--registrations', type=click.BOOL, default=True)
 def imagej_wrapper_main(do_detection: bool, do_registrations: bool):  # pragma: no cover
     """Entry point with the manifest config."""
     # logging.basicConfig(format="%(asctime)s %(name)s %(levelname)-7s %(message)s")

--- a/src/aind_exaspim_pipeline_utils/imagej_wrapper.py
+++ b/src/aind_exaspim_pipeline_utils/imagej_wrapper.py
@@ -329,6 +329,7 @@ def main():  # pragma: no cover
 
     args = dict(parser.args)
     logger.setLevel(args["log_level"])
+    logger.info(f"Args: {args}")
     args.update(get_auto_parameters(args))
     logger.info("Invocation: %s", sys.argv)
 

--- a/src/aind_exaspim_pipeline_utils/imagej_wrapper.py
+++ b/src/aind_exaspim_pipeline_utils/imagej_wrapper.py
@@ -660,7 +660,7 @@ def imagej_wrapper_main(detection: bool, registrations: bool):  # pragma: no cov
             if r != 0:
                 raise RuntimeError("IP detection command failed.")
     else:
-        if pipeline_manifest.ip_registrations and registrations:
+        if pipeline_manifest.ip_registrations:
             # At the moment we did not define an IP detection only dataset
             # We assume that interest point detections are already present in the input dataset
             # in the folder of the xml dataset file (in the manifest folder)
@@ -670,8 +670,10 @@ def imagej_wrapper_main(detection: bool, registrations: bool):  # pragma: no cov
             shutil.copytree(ip_src, "../results/interestpoints.n5", dirs_exist_ok=True)
 
     # Separate function to keep overall complexity low
-    imagej_do_registrations(pipeline_manifest, args, logger, process_meta)
-
+    if registrations:
+        imagej_do_registrations(pipeline_manifest, args, logger, process_meta)
+    else:
+        logger.info(f'registrations={registrations}, so registration will be skipped')
     logger.info("Setting processing metadata to done")
     set_metadata_done(process_meta)
     write_process_metadata(process_meta, prefix="ipreg")

--- a/src/aind_exaspim_pipeline_utils/imagej_wrapper.py
+++ b/src/aind_exaspim_pipeline_utils/imagej_wrapper.py
@@ -580,10 +580,10 @@ def imagej_do_registrations(pipeline_manifest: ExaspimProcessingPipeline,
 
 import click
 
-@click.command()
-@click.option('do_detection', type=click.BOOL, default=True)
-@click.option('do_registrations', type=click.BOOL, default=True)
-def imagej_wrapper_main(do_detection: bool, do_registration: bool):  # pragma: no cover
+@click.command
+@click.option('--do_detection', type=click.BOOL, default=True)
+@click.option('--do_registrations', type=click.BOOL, default=True)
+def imagej_wrapper_main(do_detection: bool, do_registrations: bool):  # pragma: no cover
     """Entry point with the manifest config."""
     # logging.basicConfig(format="%(asctime)s %(name)s %(levelname)-7s %(message)s")
     # arguments passed through the cli
@@ -660,7 +660,7 @@ def imagej_wrapper_main(do_detection: bool, do_registration: bool):  # pragma: n
             if r != 0:
                 raise RuntimeError("IP detection command failed.")
     else:
-        if pipeline_manifest.ip_registrations and do_registration:
+        if pipeline_manifest.ip_registrations and do_registrations:
             # At the moment we did not define an IP detection only dataset
             # We assume that interest point detections are already present in the input dataset
             # in the folder of the xml dataset file (in the manifest folder)

--- a/src/aind_exaspim_pipeline_utils/imagej_wrapper.py
+++ b/src/aind_exaspim_pipeline_utils/imagej_wrapper.py
@@ -583,6 +583,12 @@ def imagej_do_registrations(pipeline_manifest: ExaspimProcessingPipeline,
 def imagej_wrapper_main():  # pragma: no cover
     """Entry point with the manifest config."""
     # logging.basicConfig(format="%(asctime)s %(name)s %(levelname)-7s %(message)s")
+    parser = argschema.ArgSchemaParser(schema_type=ImageJWrapperSchema)
+
+    # arguments passed through the cli
+    env_args = dict(parser.args)
+    logger.setLevel(args["log_level"])
+    logger.info(f"Args: {args}")
     logging.basicConfig(format="%(asctime)s %(levelname)-7s %(message)s")
 
     # Add a file output, too for the logs
@@ -598,7 +604,7 @@ def imagej_wrapper_main():  # pragma: no cover
     args = {
         "dataset_xml": "../data/manifest/dataset.xml",
         "session_id": pipeline_manifest.pipeline_suffix,
-        "log_level": logging.DEBUG,
+        "log_level": env_args['log_level'],
         "name": pipeline_manifest.name,
         "subject_id": pipeline_manifest.subject_id,
     }
@@ -627,7 +633,7 @@ def imagej_wrapper_main():  # pragma: no cover
     )
     write_process_metadata(process_meta, prefix="ipreg")
     ip_det_parameters = pipeline_manifest.ip_detection
-    if ip_det_parameters is not None:
+    if ip_det_parameters is not None and env_args['do_detection']:
         logger.info("Copying input xml %s -> %s", args["dataset_xml"], args["process_xml"])
         shutil.copy(args["dataset_xml"], args["process_xml"])
 
@@ -656,7 +662,7 @@ def imagej_wrapper_main():  # pragma: no cover
             if r != 0:
                 raise RuntimeError("IP detection command failed.")
     else:
-        if pipeline_manifest.ip_registrations:
+        if pipeline_manifest.ip_registrations and env_args['do_registrations']:
             # At the moment we did not define an IP detection only dataset
             # We assume that interest point detections are already present in the input dataset
             # in the folder of the xml dataset file (in the manifest folder)

--- a/src/aind_exaspim_pipeline_utils/imagej_wrapper.py
+++ b/src/aind_exaspim_pipeline_utils/imagej_wrapper.py
@@ -583,7 +583,7 @@ import click
 @click.command
 @click.option('--detection', type=click.BOOL, default=True)
 @click.option('--registrations', type=click.BOOL, default=True)
-def imagej_wrapper_main(do_detection: bool, do_registrations: bool):  # pragma: no cover
+def imagej_wrapper_main(detection: bool, registrations: bool):  # pragma: no cover
     """Entry point with the manifest config."""
     # logging.basicConfig(format="%(asctime)s %(name)s %(levelname)-7s %(message)s")
     # arguments passed through the cli
@@ -631,7 +631,7 @@ def imagej_wrapper_main(do_detection: bool, do_registrations: bool):  # pragma: 
     )
     write_process_metadata(process_meta, prefix="ipreg")
     ip_det_parameters = pipeline_manifest.ip_detection
-    if ip_det_parameters is not None and do_detection:
+    if ip_det_parameters is not None and detection:
         logger.info("Copying input xml %s -> %s", args["dataset_xml"], args["process_xml"])
         shutil.copy(args["dataset_xml"], args["process_xml"])
 
@@ -660,7 +660,7 @@ def imagej_wrapper_main(do_detection: bool, do_registrations: bool):  # pragma: 
             if r != 0:
                 raise RuntimeError("IP detection command failed.")
     else:
-        if pipeline_manifest.ip_registrations and do_registrations:
+        if pipeline_manifest.ip_registrations and registrations:
             # At the moment we did not define an IP detection only dataset
             # We assume that interest point detections are already present in the input dataset
             # in the folder of the xml dataset file (in the manifest folder)

--- a/src/aind_exaspim_pipeline_utils/java_utils.py
+++ b/src/aind_exaspim_pipeline_utils/java_utils.py
@@ -3,7 +3,7 @@
 import logging
 import os
 
-from .exaspim_manifest import get_capsule_manifest
+from .exaspim_manifest import DEFAULT_OUTPUT_DIR, get_capsule_manifest
 from .imagej_wrapper import (
     create_edge_connectivity_report,
     upload_alignment_results,
@@ -11,7 +11,9 @@ from .imagej_wrapper import (
     get_auto_parameters,
 )
 from .qc.create_ng_link import create_ng_link
-
+import dotenv
+dotenv.load_dotenv()
+OUTPUT_DIR = os.environ.get('OUTPUT_DIR', DEFAULT_OUTPUT_DIR)
 
 def java_detreg_postprocess_main():  # pragma: no cover
     """Entry point for java capsule postprocessing."""
@@ -65,7 +67,7 @@ def java_detreg_postprocess_main():  # pragma: no cover
                 "{}SPIM.ome.zarr".format(args["input_uri"]),
                 args["output_uri"].rstrip("/"),
                 xml_path=xml_path,
-                output_json=f"../results/ng/process_output_{i}.json",
+                output_json=os.path.join(OUTPUT_DIR, f"ng/process_output_{i}.json"),
             )
             if thelink:
                 nglinks.append(thelink)

--- a/src/aind_exaspim_pipeline_utils/qc/create_ng_link.py
+++ b/src/aind_exaspim_pipeline_utils/qc/create_ng_link.py
@@ -12,6 +12,8 @@ from ng_link.parsers import XmlParser
 import numpy as np
 import os
 
+from aind_exaspim_pipeline_utils.exaspim_manifest import OUTPUT_DIR
+
 
 def read_json(json_path: str) -> dict:  # pragma: no cover
     """Read a json file and return a dict."""
@@ -82,8 +84,8 @@ def get_tile_positions_s3(dataset_uri: str):  # pragma: no cover
 def create_ng_link(
     dataset_uri: str,
     alignment_output_uri: str,
-    xml_path: str = "../results/bigstitcher.xml",
-    output_json: str = "../results/ng/process_output.json",
+    xml_path: str = os.path.join(OUTPUT_DIR, "bigstitcher.xml"),
+    output_json: str = os.path.join(OUTPUT_DIR, "ng/process_output.json"),
 ) -> str:  # pragma: no cover
     """ "Create a Neuroglancer json file and link file for the given alignment solution.
 
@@ -198,6 +200,6 @@ def create_ng_link(
     neuroglancer_link.save_state_as_json()
     print(neuroglancer_link.get_url_link())
     thelink = f"https://neuroglancer-demo.appspot.com/#!{alignment_output_uri}/ng/{json_name}"
-    with open("../results/ng/ng_link.txt", "a") as f:
+    with open(os.path.join(OUTPUT_DIR, "ng/ng_link.txt"), "a") as f:
         print(thelink, file=f)
     return thelink

--- a/src/aind_exaspim_pipeline_utils/qc/image_cutout.py
+++ b/src/aind_exaspim_pipeline_utils/qc/image_cutout.py
@@ -2,11 +2,13 @@
 import logging
 import sys
 from typing import Optional, Iterable
-
+import os
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 import xmltodict
+
+from aind_exaspim_pipeline_utils.exaspim_manifest import OUTPUT_DIR
 
 from .bbox import Bbox
 from .tile_transformations import (
@@ -574,7 +576,7 @@ def run_aff_cutout_plot():  # pragma: no cover
     formatter = logging.Formatter("%(asctime)s %(name)s %(levelname)s %(message)s")
     handler.setFormatter(formatter)
     rlogger.addHandler(handler)
-    run_pair_overplots("../results/bigstitcher.xml", prefix="../results/aff_")
+    run_pair_overplots(os.path.join(OUTPUT_DIR, "bigstitcher.xml"), prefix=os.path.join(OUTPUT_DIR, "aff_"))
 
 
 def run_aff_combined_plot():  # pragma: no cover
@@ -587,7 +589,7 @@ def run_aff_combined_plot():  # pragma: no cover
     formatter = logging.Formatter("%(asctime)s %(name)s %(levelname)s %(message)s")
     handler.setFormatter(formatter)
     rlogger.addHandler(handler)
-    run_combined_plots("../results/bigstitcher.xml", prefix="../results/aff_")
+    run_combined_plots(os.path.join(OUTPUT_DIR,"bigstitcher.xml"), prefix=os.path.join(OUTPUT_DIR,"aff_"))
 
 
 def run_aff_yz_xz_combined_plot():  # pragma: no cover
@@ -601,5 +603,5 @@ def run_aff_yz_xz_combined_plot():  # pragma: no cover
     handler.setFormatter(formatter)
     rlogger.addHandler(handler)
     run_combined_plots(
-        "../results/bigstitcher.xml", prefix="../results/aff_", vert_proj_axis=0, hor_proj_axis=1
+        os.path.join(OUTPUT_DIR, "bigstitcher.xml"), prefix=os.path.join(OUTPUT_DIR,"aff_"), vert_proj_axis=0, hor_proj_axis=1
     )

--- a/src/aind_exaspim_pipeline_utils/qc/ip_density.py
+++ b/src/aind_exaspim_pipeline_utils/qc/ip_density.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import sys
 from typing import Optional
-
+import os
 import numpy as np
 
 import xmltodict
@@ -13,6 +13,8 @@ from matplotlib.backends.backend_pdf import PdfPages
 
 import matplotlib.pyplot as plt
 import matplotlib.ticker as ticker
+
+from aind_exaspim_pipeline_utils.exaspim_manifest import OUTPUT_DIR
 from .tile_transformations import (
     get_tile_overlapping_IPs,
     get_tile_pair_overlap,
@@ -237,7 +239,7 @@ def run_tr_density_plot():  # pragma: no cover
     formatter = logging.Formatter("%(asctime)s %(name)s %(levelname)s %(message)s")
     handler.setFormatter(formatter)
     rlogger.addHandler(handler)
-    run_density_plot("../results/bigstitcher.xml", prefix="../results/tr_")
+    run_density_plot(os.path.join(OUTPUT_DIR, "bigstitcher.xml"), prefix=os.path.join(OUTPUT_DIR, "tr_"))
 
 
 def run_aff_density_plot():  # pragma: no cover
@@ -250,4 +252,4 @@ def run_aff_density_plot():  # pragma: no cover
     formatter = logging.Formatter("%(asctime)s %(name)s %(levelname)s %(message)s")
     handler.setFormatter(formatter)
     rlogger.addHandler(handler)
-    run_density_plot("../results/bigstitcher.xml", prefix="../results/aff_")
+    run_density_plot(os.path.join(OUTPUT_DIR, "bigstitcher.xml"), prefix=os.path.join(OUTPUT_DIR, "aff_"))

--- a/src/aind_exaspim_pipeline_utils/qc/ng_ip_visualization.py
+++ b/src/aind_exaspim_pipeline_utils/qc/ng_ip_visualization.py
@@ -11,6 +11,8 @@ from ng_link.parsers import XmlParser
 import s3fs
 import zarr
 
+from aind_exaspim_pipeline_utils.exaspim_manifest import OUTPUT_DIR
+
 
 def read_json(json_path: str) -> dict:  # pragma: no cover
     """Read a json file and return a dict."""
@@ -47,7 +49,7 @@ def read_in_n5_ips(tile_setupId, transform_3x4=None):  # pragma: no cover
     """Read in intereset point coordinates from the n5 binary files.
     Interest points are not sorted.
     """
-    n5s = zarr.n5.N5FSStore("../results/interestpoints.n5/")
+    n5s = zarr.n5.N5FSStore(os.path.join(OUTPUT_DIR, "interestpoints.n5/"))
     zg = zarr.open(store=n5s, mode="r")
 
     id = zg[f"tpId_0_viewSetupId_{tile_setupId}/beads/interestpoints/id"]
@@ -115,8 +117,8 @@ def get_tile_positions_s3(dataset_uri: str):  # pragma: no cover
 def create_ng_link_with_annotation(
     dataset_uri: str,
     alignment_output_uri: str,
-    xml_path: str = "../results/bigstitcher.xml",
-    output_json: str = "../results/ng/process_output.json",
+    xml_path: str = os.path.join(OUTPUT_DIR, "bigstitcher.xml"),
+    output_json: str = os.path.join(OUTPUT_DIR, "ng/process_output.json"),
 ) -> str:  # pragma: no cover
     """ "Create a Neuroglancer json file and link file for the given alignment solution.
 
@@ -265,6 +267,6 @@ def create_ng_link_with_annotation(
     # thelink = f"https://neuroglancer-demo.appspot.com/#!{alignment_output_uri}/ng/{json_name}"
     # Local installation
     thelink = f"https://aind-neuroglancer-sauujisjxq-uw.a.run.app/#!{alignment_output_uri}/ng/{json_name}"
-    with open("../results/ng/ng_link.txt", "a") as f:
+    with open(os.path.join(OUTPUT_DIR, "ng/ng_link.txt"), "a") as f:
         print(thelink, file=f)
     return thelink

--- a/src/aind_exaspim_pipeline_utils/qc/tile_transformations.py
+++ b/src/aind_exaspim_pipeline_utils/qc/tile_transformations.py
@@ -1,14 +1,17 @@
 """Tile transformations and overlap functions for QC plotting."""
 from __future__ import annotations
-
+import os
 import logging
 import json
+import os
 import numpy as np
 import numpy.lib.recfunctions
 import scipy
 import zarr
 from collections import OrderedDict
 import pandas as pd
+
+from aind_exaspim_pipeline_utils.imagej_wrapper import OUTPUT_DIR
 
 from .affine_transformation import AffineTransformation  # pragma: no cover
 from .bbox import Bbox  # pragma: no cover
@@ -209,7 +212,7 @@ def get_tile_pair_overlap(
 
 
 def read_tiles_interestpoints(
-    ip_label="beads", path: str = "../results/interestpoints.n5"
+    ip_label="beads", path: str = os.path.join(OUTPUT_DIR, "interestpoints.n5")
 ) -> dict[int, np.ndarray]:  # pragma: no cover
     """
 
@@ -245,7 +248,7 @@ def read_tiles_interestpoints(
 
 
 def read_ip_correspondences(
-    ip_label: str = "beads", path: str = "../results/interestpoints.n5"
+    ip_label: str = "beads", path: str = os.path.join(OUTPUT_DIR, "interestpoints.n5")
 ) -> tuple[dict[int, np.ndarray], dict[int, dict[str, int]]]:  # pragma: no cover
     """Read in the interest point correspondences from the n5 binary files.
 


### PR DESCRIPTION
this PR contains two separate changes; happy to factor them out into two separate PRs, if that's helpful.
1. add a dependency on `python-dotenv`, and use environment variables or a .env file to specify output / input file paths. This makes the code more reusable and easier to test locally.
2.  add a dependency on `click`, and make `imagej_wrapper_main` a `click.command`; `imagej_wrapper_main` now takes two boolean arguments, which determine whether points should be estimated, and whether affine transforms should be estimated. This allows only invoking the command to only generate points, or only generate affine transforms.