### PR TITLE
Feat: updates dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,10 @@ dependencies = [
     'psutil',
     'matplotlib',
     'scipy',
-    'aind-data-schema',
-    'aind-codeocean-api==0.3.0',
+    'aind-data-schema==0.33.3',
+    'aind-codeocean-api',
     'aind-ng-link>=1.0.15',
+    'numpy<2.0'
 ]
 
 [project.optional-dependencies]
@@ -46,11 +47,11 @@ n5tozarr = [
     'distributed',
     'zarr',
     'numcodecs',
-    'aind-data-transfer[full]==0.32.0',
-    # missing dependencies from aind-data-transfer[full]
+    'aind-data-transfer[imaging]==0.35.3',
+    # missing dependencies from aind-data-transfer[imaging]
     # These supposed to be installed by post_install.sh
-#    'hdf5plugin',
-#    'kerchunk'
+    'hdf5plugin',
+    'kerchunk'
 ]
 
 [tool.setuptools.packages.find]

--- a/src/aind_exaspim_pipeline_utils/exaspim_manifest.py
+++ b/src/aind_exaspim_pipeline_utils/exaspim_manifest.py
@@ -478,7 +478,7 @@ def create_example_manifest(printit=True) -> ExaspimProcessingPipeline | None:  
     )
 
     if printit:
-        print(processing_manifest_example.json(indent=3))
+        print(processing_manifest_example.model_dump_json(indent=3))
         return  # If printed, we assume call from the cli
     return processing_manifest_example
 
@@ -543,7 +543,7 @@ def write_process_metadata(capsule_metadata: DataProcess, prefix=None) -> None: 
         prefix = prefix + "_"
     # with open(f"../results/meta/exaspim_{prefix}process.json", "w") as f:
     with open("../results/process_output.json", "w") as f:
-        f.write(capsule_metadata.json(indent=3))
+        f.write(capsule_metadata.model_dump_json(indent=3))
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/aind_exaspim_pipeline_utils/exaspim_manifest.py
+++ b/src/aind_exaspim_pipeline_utils/exaspim_manifest.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 import json
 import os
 from datetime import datetime
-from typing import Optional, Tuple, List, Union
+from typing import Optional, Tuple, List, Union, Literal
 
-from aind_data_schema import DataProcess
+from aind_data_schema.core.processing import DataProcess
 from aind_data_schema.base import AindModel
 from pydantic import Field, validator
 import argparse
@@ -409,8 +409,8 @@ class ExaspimProcessingPipeline(AindModel):  # pragma: no cover
 
     If a field is None, it is considered to be a disabled step."""
 
-    schema_version: str = Field("0.11.0", title="Schema Version", const=True)
-    license: str = Field("CC-BY-4.0", title="License", const=True)
+    schema_version: Literal["0.11.0"]
+    license: Literal["CC-BY-4.0"]
 
     creation_time: datetime = Field(
         ...,

--- a/src/aind_exaspim_pipeline_utils/imagej_wrapper.py
+++ b/src/aind_exaspim_pipeline_utils/imagej_wrapper.py
@@ -440,7 +440,7 @@ def get_imagej_wrapper_metadata(
         code_url="https://github.com/AllenNeuralDynamics/aind-exaSPIM-pipeline-utils",
         code_version=__version__,
         parameters=parameters,
-        outputs=None,
+        outputs={},
         notes="IN PROGRESS",
     )
     return dp

--- a/src/aind_exaspim_pipeline_utils/imagej_wrapper.py
+++ b/src/aind_exaspim_pipeline_utils/imagej_wrapper.py
@@ -16,11 +16,8 @@ import argschema.fields as fld
 import marshmallow as mm
 import psutil
 import s3fs
-from aind_data_schema.processing import DataProcess, ProcessName
+from aind_data_schema.core.processing import DataProcess, ProcessName
 import xml.etree.ElementTree as ET
-
-# from aind_data_schema import DataProcess
-# from aind_data_schema.processing import ProcessName
 
 from . import __version__
 from .imagej_macros import ImagejMacros

--- a/src/aind_exaspim_pipeline_utils/n5tozarr/n5tozarr_da.py
+++ b/src/aind_exaspim_pipeline_utils/n5tozarr/n5tozarr_da.py
@@ -4,8 +4,8 @@ import logging
 import sys
 
 import xarray_multiscale
-from aind_data_schema import DataProcess
-from aind_data_schema.processing import ProcessName
+from aind_data_schema.core.processing import DataProcess
+from aind_data_schema.core.processing import ProcessName
 from aind_data_transfer.transformations.ome_zarr import _get_first_mipmap_level
 from aind_data_transfer.util.io_utils import BlockedArrayWriter
 from numcodecs.abc import Codec

--- a/src/aind_exaspim_pipeline_utils/n5tozarr/n5tozarr_da.py
+++ b/src/aind_exaspim_pipeline_utils/n5tozarr/n5tozarr_da.py
@@ -394,7 +394,7 @@ def get_zarr_multiscale_metadata(config: dict):  # pragma: no cover
         code_url="https://github.com/AllenNeuralDynamics/aind-exaSPIM-pipeline-utils",
         code_version=aind_exaspim_pipeline_utils.__version__,
         parameters=config,
-        outputs=None,
+        outputs={},
         notes="IN PROGRESS",
     )
     return dp
@@ -413,7 +413,7 @@ def get_n5tozarr_metadata(config: dict):  # pragma: no cover
         code_url="https://github.com/AllenNeuralDynamics/aind-exaSPIM-pipeline-utils",
         code_version=aind_exaspim_pipeline_utils.__version__,
         parameters=config,
-        outputs=None,
+        outputs={},
         notes="IN PROGRESS",
     )
     return dp

--- a/src/aind_trigger_codeocean/pipelines.py
+++ b/src/aind_trigger_codeocean/pipelines.py
@@ -13,8 +13,7 @@ from typing import Dict, List, Optional
 
 import requests
 
-# from aind_data_schema.core.data_description import DataLevel
-from aind_data_schema.data_description import DataLevel
+from aind_data_schema.core.data_description import DataLevel
 from aind_codeocean_api.codeocean import CodeOceanClient
 from aind_codeocean_api.models.computations_requests import (
     ComputationDataAsset, RunCapsuleRequest)


### PR DESCRIPTION
Updates for the latest `aind-data-transfer` and the (more recent) version of `aind-data-schema` that is required by `aind-data-transfer`. If we want to upgrade to `aind-data-schema==1.0.0`, we will need to update `aind-data-transfer` as well. I did not do that since that repository is deprecated and no longer actively maintained. Perhaps others have thoughts on this.

I tested the n5tozarr converter, but did not test the other functionality. Would appreciate if someone else could test it, otherwise I would be happy to if someone can point me to a test dataset and their capsule.